### PR TITLE
Support loading datasets via dict() & update SimilarityInterleaved

### DIFF
--- a/src/megatron/energon/dataset_config.py
+++ b/src/megatron/energon/dataset_config.py
@@ -17,17 +17,17 @@ MAIN_FOLDER_NAME = ".nv-meta"
 
 
 def load_config(
-    path: EPath,
+    path: Union[EPath, Dict[str, Any]],
     *,
     default_type: Optional[Type[T]] = None,
     strict: bool = True,
     default_kwargs: Optional[Dict[str, Any]] = None,
 ) -> T:
     """
-    Loads a config from a file.
+    Loads a config from a file or directly from a dictionary.
 
     Args:
-        path: Path to the config to load
+        path: Path to the config to load or a dictionary containing the config.
         default_type: If set, this is the type to use if no type is specified in the config.
         strict: If true, don't allow additional attributes in the config.
         default_kwargs: Default kwargs to use, will be overridden by the config.
@@ -35,14 +35,19 @@ def load_config(
     Returns:
         The instantiated type.
     """
-    # Read the config
-    path = path.absolute()
-    with path.open() as f:
-        data: dict = yaml.safe_load(f)
+    if isinstance(path, dict):
+        data = path
+    else:
+        # Read the config from a file
+        path = path.absolute()
+        with path.open() as f:
+            data: dict = yaml.safe_load(f)
+    
     if default_kwargs is not None:
         new_data = default_kwargs.copy()
         new_data.update(data)
         data = new_data
+    
     return raw_to_instance(data, default_type, strict=strict)
 
 

--- a/src/megatron/energon/flavors/similarity_interleaved.py
+++ b/src/megatron/energon/flavors/similarity_interleaved.py
@@ -22,7 +22,9 @@ class SimilarityInterleavedSample(Sample):
 
     #: Similarity matrix between image and text entries in the sequence
     similarity_matrix: Optional[torch.Tensor] = None
-
+    
+    #: The index within texts representing the sentence that this image is matched to
+    matched_text_indices: Optional[List[int]] = None
 
 class SimilarityInterleavedWebdataset(DefaultDecoderWebdataset[SimilarityInterleavedSample]):
     __sample_type__ = SimilarityInterleavedSample

--- a/src/megatron/energon/metadataset/loader.py
+++ b/src/megatron/energon/metadataset/loader.py
@@ -16,8 +16,15 @@ def load_dataset(
     **kwargs,
 ) -> DatasetLoaderInterface:
     """Loads a (meta)dataset."""
-    path = EPath(path).absolute()
 
+    if isinstance(path,dict):
+        return load_config(
+            path,
+            default_type=Metadataset,
+            strict=True,
+            default_kwargs=dict(parent_path="/tmp/dict", **kwargs),
+        )
+    path = EPath(path).absolute()
     if path.is_file():
         return load_config(
             path,

--- a/src/megatron/energon/metadataset/loader.py
+++ b/src/megatron/energon/metadataset/loader.py
@@ -17,12 +17,12 @@ def load_dataset(
 ) -> DatasetLoaderInterface:
     """Loads a (meta)dataset."""
 
-    if isinstance(path,dict):
+    if isinstance(path, dict):
         return load_config(
             path,
             default_type=Metadataset,
             strict=True,
-            default_kwargs=dict(parent_path="/tmp/dict", **kwargs),
+            default_kwargs=dict(parent_path=EPath("/"), **kwargs),
         )
     path = EPath(path).absolute()
     if path.is_file():


### PR DESCRIPTION
1. This provides support for loading datasets with type dict. Previously, Energon only accepted paths to YAML files which does not integrate cleanly with libraries like NeMo.

2. I've also updated SimilarityInterleavedSample to include optional matched_text_indices list, to closely match format for datasets like MMC4.