### PR TITLE
Allow for reproducible scaling with different micro batch size

### DIFF
--- a/docs/source/repro_scaling.md
+++ b/docs/source/repro_scaling.md
@@ -10,7 +10,6 @@ Since version 2.0.0, Megatron Energon supports this behavior if a few constraint
 * The global batch size must stay the same across runs
 * The global batch size must be a multiple of `micro-batch size * world_size * num_workers`
   * The multiple of that is the number of gradient accumulation steps in your training
-* The micro-batch size must stay the same across runs
 * The product `world_size * num_workers` must stay the same across runs, such that the global number of workers stays the same
 * You need to set the same `torch.manual_seed(...)` on each rank before constructing the dataset and the data loader
 

--- a/tests/test_dataset_det.py
+++ b/tests/test_dataset_det.py
@@ -420,7 +420,6 @@ class TestDataset(unittest.TestCase):
         # - Global batch size must stay the same across runs
         # - Global batch size must be a multiple of (micro-batch size * world_size * num_workers)
         #   - Global batch size = micro-batch size * world_size * num_workers * gradient_accum_steps
-        # - The micro-batch size must stay the same across runs
         # - world_size * num_workers must stay the same across runs
         # Set the same torch.manual_seed(...) on each rank before constructing the dataset and the data loader
 
@@ -446,6 +445,14 @@ class TestDataset(unittest.TestCase):
                     WorkerConfig(rank=3, world_size=4, num_workers=1),
                 ),
                 micro_batch_size=2,
+                global_batch_size=8,
+            ),
+            dict(
+                configs=(
+                    WorkerConfig(rank=0, world_size=2, num_workers=2),
+                    WorkerConfig(rank=1, world_size=2, num_workers=2),
+                ),
+                micro_batch_size=1,  # Micro-batch 1, more accum
                 global_batch_size=8,
             ),
         ]


### PR DESCRIPTION
We lift the constraints needed to reproduce the global batches under different parallelism.
When increasing or decreasing the micro batch size and adapting the gradient accumulation accordingly, the global batches will also remain the same.

This is now reflected in the documentation and the unit test.