### PR TITLE
Hotfix: After fork, only reset fsspec asyn loop if it has been initialized

### DIFF
--- a/src/megatron/energon/epathlib/epath.py
+++ b/src/megatron/energon/epathlib/epath.py
@@ -155,8 +155,10 @@ class EPath:
         It is independent of any EPath instances. For those, see the fork_guard() below.
         """
 
-        fsspec.asyn.iothread[0] = None  # type: ignore
-        fsspec.asyn.loop[0] = None  # type: ignore
+        if hasattr(fsspec, "asyn"):
+            fsspec.asyn.iothread[0] = None  # type: ignore
+            fsspec.asyn.loop[0] = None  # type: ignore
+        
         s3fs.S3FileSystem.clear_instance_cache()
 
     def fork_guard(self):


### PR DESCRIPTION
In some python environments, we got the error
`AttributeError: module 'fsspec' has no attribute 'asyn'`
From the `epath.py` line `fsspec.asyn.iothread[0] = None` which is meant to reset the async loop after forking a process with fsspec. With this fix, we only reset the loop if it has been initialized previously.