### PR TITLE
Fix the implementation of grouped batching

### DIFF
--- a/docs/source/grouping.md
+++ b/docs/source/grouping.md
@@ -3,11 +3,10 @@ SPDX-License-Identifier: BSD-3-Clause -->
 
 # Grouping
 
-Grouping allows for rule-based batching of samples into one batch on the fly. 
+Grouping allows for rule-based batching of samples into one batch on the fly.
 
-Note how this is different from [packing](packing) which is done *in addition* to batching (it's done before batching) and
-joins multiple samples into one.
-On the other hand grouping *replaces* standard batching.
+Note how this is different from [packing](packing) which joins multiple samples into one (and is done before batching).
+On the other hand, grouping is an alternative to standard batching.
 
 ## Example use cases
 

--- a/docs/source/grouping.md
+++ b/docs/source/grouping.md
@@ -1,0 +1,43 @@
+<!--- Copyright (c) 2024, NVIDIA CORPORATION.
+SPDX-License-Identifier: BSD-3-Clause -->
+
+# Grouping
+
+While [packing](packing) joins multiple samples into one sample, grouping allows for rule-based batching of samples into
+one batch on the fly.
+
+That means, while packing is done in addition to batching (it's done before), grouping replaces standard batching.
+
+## Example use cases
+
+* Select samples to batch based on image resolution, so that only samples of the same size are in one batch
+* Select blended samples based on their dataset origin, so that one batch does not mix different tasks or data types
+
+## How to group
+
+To use grouping, you need to define the method `batch_group_criterion` in your custom task encoder.
+This method gets a sample and returns a hashable value that will be used to cluster/group the samples
+and it also returns the batch size for that group.
+Samples with the same batch group criterion will be batched together. Once enough samples for one group
+have been collected (reached the batch size for that group), they will be batched and pushed down the pipeline
+to the next processing step.
+
+Here's and example task encoder that batches samples based on the file name in their sample key.
+
+```python
+class GroupingTaskEncoder(
+    TaskEncoder[CaptioningSample, CaptioningSample, CaptioningSample, CaptioningSample]
+):
+    @stateless
+    def encode_sample(self, sample: CaptioningSample) -> CaptioningSample:
+        sample.caption = sample.__key__.split("/")[-2]
+        return sample
+
+    def batch_group_criterion(self, sample: CaptioningSample) -> Tuple[Hashable, int]:
+        if sample.caption == "data-0.tar":
+            return "shard1", 4
+        elif sample.caption == "data-1.tar":
+            return "shard2", 8
+        else:
+            assert False
+```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -57,6 +57,7 @@ maxdepth: 2
 advanced_dataformat
 repro_scaling
 packing
+grouping
 joining_datasets
 ```
 

--- a/src/megatron/energon/task_encoder/base.py
+++ b/src/megatron/energon/task_encoder/base.py
@@ -260,11 +260,16 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
         """Move a batch to a device. May raise :exc:`megatron.energon.SkipSample` to skip a batch."""
         return self._batch(samples, type(samples[0]))
 
-    def batch_group_criterion(self, sample: T_encoded_sample) -> Hashable:
-        """Return a group criterion for the sample. Default implementation does not group
-        (effectively, it returns a single value (`None`), thus only one group is used). May raise
-        :exc:`megatron.energon.SkipSample` to skip a batch."""
-        return None
+    def batch_group_criterion(self, sample: T_encoded_sample) -> Tuple[Hashable, Optional[int]]:
+        """
+        Return a group criterion for the sample. Default implementation does not group
+        (effectively, it returns a single value `(None, None)`, thus only one group is used).
+        Returns the key of the bucket to put this sample into, and the size of the bucket (=batch size).
+        The bucket size must always be the same for the same bucket key.
+
+        May raise :exc:`megatron.energon.SkipSample` to skip a batch.
+        """
+        return None, None
 
     @stateless
     def encode_batch(self, batch: T_raw_batch) -> Union[T_batch, Generator[T_batch, None, None]]:
@@ -361,45 +366,46 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
     ) -> SavableDataset[T_raw_batch]:
         """Applies the batcher to the dataset."""
 
+        if packing_buffer_size is not None:
+            select_samples_to_pack_provided = (
+                getattr(self.select_samples_to_pack, "__func__", None)
+                is not TaskEncoder.select_samples_to_pack
+            )
+            pack_selected_samples_provided = (
+                getattr(self.pack_selected_samples, "__func__", None)
+                is not TaskEncoder.pack_selected_samples
+            )
+
+            assert (
+                select_samples_to_pack_provided and pack_selected_samples_provided
+            ), "Both select_samples_to_pack and pack_selected_samples methods must be provided in the TaskEncoder when using packing_buffer_size"
+
+            dataset = PackingDataset(
+                dataset,
+                buffer_size=packing_buffer_size,
+                pre_packer=self.select_samples_to_pack,
+                final_packer=self.pack_selected_samples,
+                final_packer_stateless=get_stateless(self.pack_selected_samples),
+                worker_config=worker_config,
+            )
+
         if (
             getattr(self.batch_group_criterion, "__func__", None)
             is not TaskEncoder.batch_group_criterion
         ):
-            assert batch_size is not None, "batch_size must be set if batch_group_criterion is set"
-            assert packing_buffer_size is None, "Packing not supported when grouping"
+            assert (
+                batch_size is None
+            ), "batch_size must not be set if batch_group_criterion is defined"
             dataset = GroupBatchDataset(
                 dataset,
-                batch_size=batch_size,
-                group_criterion=self.batch_group_criterion,
+                default_batch_size=batch_size,
+                sample_group_key=self.batch_group_criterion,
                 batcher=self.batch,
                 drop_last=batch_drop_last,
                 worker_config=worker_config,
             )
         else:
             # No grouping is active
-
-            if packing_buffer_size is not None:
-                select_samples_to_pack_provided = (
-                    getattr(self.select_samples_to_pack, "__func__", None)
-                    is not TaskEncoder.select_samples_to_pack
-                )
-                pack_selected_samples_provided = (
-                    getattr(self.pack_selected_samples, "__func__", None)
-                    is not TaskEncoder.pack_selected_samples
-                )
-
-                assert (
-                    select_samples_to_pack_provided and pack_selected_samples_provided
-                ), "Both select_samples_to_pack and pack_selected_samples methods must be provided in the TaskEncoder when using packing_buffer_size"
-
-                dataset = PackingDataset(
-                    dataset,
-                    buffer_size=packing_buffer_size,
-                    pre_packer=self.select_samples_to_pack,
-                    final_packer=self.pack_selected_samples,
-                    final_packer_stateless=get_stateless(self.pack_selected_samples),
-                    worker_config=worker_config,
-                )
 
             if batch_size is not None:
                 dataset = BatchDataset(
@@ -480,7 +486,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
         *,
         datasets: List[Tuple[BaseCoreDatasetFactory[T_sample], float]],
         worker_config: WorkerConfig,
-        batch_size: int,
+        batch_size: Optional[int],
         batch_drop_last: bool = False,
         packing_buffer_size: Optional[int] = None,
         virtual_epoch_length: int = 0,
@@ -727,9 +733,6 @@ class AugmentTaskEncoder(
 
     def batch(self, samples: List[T_encoded_sample]) -> T_raw_batch:
         return self._task_encoder.batch(samples)
-
-    def batch_group_criterion(self, sample: T_encoded_sample) -> Hashable:
-        return self._task_encoder.batch_group_criterion(sample)
 
     def encode_batch(self, batch_data: T_raw_batch) -> T_batch:
         return self._task_encoder.encode_batch(batch_data)

--- a/src/megatron/energon/task_encoder/base.py
+++ b/src/megatron/energon/task_encoder/base.py
@@ -396,12 +396,9 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
             getattr(self.batch_group_criterion, "__func__", None)
             is not TaskEncoder.batch_group_criterion
         ):
-            assert (
-                batch_size is None
-            ), "batch_size must not be set if batch_group_criterion is defined"
             dataset = GroupBatchDataset(
                 dataset,
-                default_batch_size=batch_size,
+                fixed_batch_size=batch_size,
                 sample_group_key=self.batch_group_criterion,
                 batcher=self.batch,
                 drop_last=batch_drop_last,

--- a/src/megatron/energon/task_encoder/loader.py
+++ b/src/megatron/energon/task_encoder/loader.py
@@ -38,7 +38,7 @@ def get_train_dataset(
     *,
     split_part: Union[Literal["train"], str] = "train",
     worker_config: WorkerConfig,
-    batch_size: int,
+    batch_size: Optional[int],
     batch_drop_last: bool = False,
     packing_buffer_size: Optional[int] = None,
     shuffle_buffer_size: Optional[int],
@@ -63,7 +63,7 @@ def get_train_dataset(
         path: Path to the dataset.
         split_part: Default split part to use.
         worker_config: Worker configuration to use.
-        batch_size: Size of a batch
+        batch_size: Size of a batch. If None, do not batch
         batch_drop_last: If true, drop the last batch if it is smaller than `batch_size`.
         shuffle_buffer_size: Size of the sample shuffle buffer (before task encoding).
         max_samples_per_sequence: If set, limit the number of samples per sample-sequence to this.

--- a/src/megatron/energon/wrappers/base.py
+++ b/src/megatron/energon/wrappers/base.py
@@ -20,9 +20,9 @@ from megatron.energon.flavors.base_dataset import MergedState, Sample, SavableDa
 from megatron.energon.worker import WorkerConfig
 
 T = TypeVar("T")
-T_sample = TypeVar("T_sample")
-T_sample_out = TypeVar("T_sample_out")
-T_sample_in = TypeVar("T_sample_in")
+T_sample = TypeVar("T_sample", covariant=True)
+T_sample_out = TypeVar("T_sample_out", covariant=True)
+T_sample_in = TypeVar("T_sample_in", covariant=True)
 
 
 @dataclass

--- a/src/megatron/energon/wrappers/buffer.py
+++ b/src/megatron/energon/wrappers/buffer.py
@@ -2,31 +2,38 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from dataclasses import dataclass
-from typing import Any, Dict, Generator, Generic, Iterator, List, Optional, Tuple, TypeVar, Union
-
-from megatron.energon.flavors.base_dataset import SavableDataset
-from megatron.energon.worker import WorkerConfig
-from megatron.energon.wrappers.base import (
-    BaseSingleWrapperDataset,
-    BaseSingleWrapperMergedState,
-    BaseSingleWrapperState,
-    get_sample_restore_key,
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    Generic,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
 )
+
+from megatron.energon.flavors.base_dataset import MergedState, SavableDataset, State
+from megatron.energon.worker import WorkerConfig
+from megatron.energon.wrappers.base import BaseWrapperDataset, get_sample_restore_key
 
 T_sample = TypeVar("T_sample")
 
 
 @dataclass
-class SampleBufferState(BaseSingleWrapperState):
+class SampleBufferState(State):
     buffer: List[Tuple[Union[str, int], ...]]
 
 
 @dataclass
-class SampleBufferMergedState(BaseSingleWrapperMergedState):
+class SampleBufferMergedState(MergedState):
     buffer: List[List[Tuple[Union[str, int], ...]]]
 
 
-class SavableSampleBuffer(BaseSingleWrapperDataset[T_sample, T_sample], Generic[T_sample]):
+class SavableSampleBuffer(BaseWrapperDataset[T_sample], Generic[T_sample]):
     """A buffer of samples, savable."""
 
     _buffer: List[List[T_sample]]
@@ -38,7 +45,7 @@ class SavableSampleBuffer(BaseSingleWrapperDataset[T_sample, T_sample], Generic[
     __rank_id: Optional[int] = None
 
     def __init__(self, dataset: SavableDataset[T_sample], worker_config: WorkerConfig):
-        super().__init__(dataset)
+        self.dataset = dataset
         self.worker_config = worker_config
         self._buffer = [[] for _ in range(max(worker_config.num_workers, 1))]
         self._restore_keys = [[] for _ in range(max(worker_config.num_workers, 1))]
@@ -68,11 +75,14 @@ class SavableSampleBuffer(BaseSingleWrapperDataset[T_sample, T_sample], Generic[
         self._restore_keys[self._rank_id].append(get_sample_restore_key(sample))
         return sample
 
-    def extend(self, samples: List[T_sample]) -> None:
+    def extend(self, samples: List[T_sample], restore_keys: Optional[Sequence[Any]] = None) -> None:
         self._buffer[self._rank_id].extend(samples)
-        self._restore_keys[self._rank_id].extend(
-            get_sample_restore_key(sample) for sample in samples
-        )
+        if restore_keys is None:
+            self._restore_keys[self._rank_id].extend(
+                get_sample_restore_key(sample) for sample in samples
+            )
+        else:
+            self._restore_keys[self._rank_id].extend(restore_keys)
 
     def append_iter(self) -> Generator[T_sample, None, None]:
         for sample in self.dataset:
@@ -81,6 +91,13 @@ class SavableSampleBuffer(BaseSingleWrapperDataset[T_sample, T_sample], Generic[
     def pop(self, index: int) -> T_sample:
         self._restore_keys[self._rank_id].pop(index)
         return self._buffer[self._rank_id].pop(index)
+
+    def flush(self) -> Tuple[List[T_sample], Tuple[Any, ...]]:
+        buffer = list(self._buffer[self._rank_id])
+        restore_key = tuple(self._restore_keys[self._rank_id])
+        self._buffer[self._rank_id].clear()
+        self._restore_keys[self._rank_id].clear()
+        return buffer, restore_key
 
     def __iter__(self) -> Iterator[T_sample]:
         return iter(self._buffer[self._rank_id])
@@ -104,20 +121,17 @@ class SavableSampleBuffer(BaseSingleWrapperDataset[T_sample, T_sample], Generic[
 
     def save_state(self) -> SampleBufferState:
         self.dataset.assert_can_restore()
-        return SampleBufferState.extend(
-            super().save_state(),
+        return SampleBufferState(
             buffer=list(self._restore_keys[self._rank_id]),
         )
 
     def merge_states(self, states: List[Optional[SampleBufferState]]) -> SampleBufferMergedState:
         assert all(s is None or isinstance(s, SampleBufferState) for s in states)
-        return SampleBufferMergedState.extend(
-            super().merge_states(states),
+        return SampleBufferMergedState(
             buffer=[[] if s is None else s.buffer for s in states],
         )
 
     def restore_state(self, state: Optional[SampleBufferMergedState]) -> None:
-        super().restore_state(state)
         if state is None:
             self._buffer = [[] for _ in range(max(self.worker_config.num_workers, 1))]
             self._restore_keys = [[] for _ in range(max(self.worker_config.num_workers, 1))]
@@ -145,6 +159,9 @@ class SavableSampleBuffer(BaseSingleWrapperDataset[T_sample, T_sample], Generic[
 
     def restore_sample(self, index: Tuple[Union[str, int, tuple], ...]) -> T_sample:
         return self.dataset.restore_sample(index)
+
+    def worker_has_samples(self) -> bool:
+        return self.dataset.worker_has_samples()
 
     def clear(self) -> None:
         self._buffer[self._rank_id].clear()

--- a/src/megatron/energon/wrappers/group_batch_dataset.py
+++ b/src/megatron/energon/wrappers/group_batch_dataset.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import inspect
 from dataclasses import dataclass
 from typing import (
     Any,
     Callable,
     Dict,
+    Generator,
     Generic,
     Hashable,
     Iterator,
@@ -17,13 +19,24 @@ from typing import (
 )
 
 from megatron.energon.errors import SYSTEM_EXCEPTIONS, FatalSampleError
-from megatron.energon.flavors.base_dataset import SavableDataset
+from megatron.energon.flavors.base_dataset import (
+    MergedState,
+    SavableDataset,
+    State,
+    set_sample_restore_key,
+)
 from megatron.energon.worker import WorkerConfig
 from megatron.energon.wrappers._log_exception import log_exception
 from megatron.energon.wrappers.base import (
     BaseSingleWrapperDataset,
     BaseSingleWrapperMergedState,
     BaseSingleWrapperState,
+    SampleIndex,
+)
+from megatron.energon.wrappers.buffer import (
+    SampleBufferMergedState,
+    SampleBufferState,
+    SavableSampleBuffer,
 )
 from megatron.energon.wrappers.skip import SkipSample
 
@@ -32,104 +45,147 @@ T_batch_sample = TypeVar("T_batch_sample", covariant=True)
 
 
 @dataclass
+class BucketState(State):
+    key: Hashable
+    batch_size: int
+    samples: SampleBufferState
+
+
+@dataclass
+class BucketMergedState(MergedState):
+    key: Hashable
+    batch_size: int
+    samples: SampleBufferState
+
+
+@dataclass
 class GroupBatchState(BaseSingleWrapperState):
-    batches: Any
+    bucket_sample_index: int
+    batch_sample_index: int
+    buckets: List[BucketState]
 
 
 @dataclass
 class GroupBatchMergedState(BaseSingleWrapperMergedState):
-    batches: List[Any]
+    bucket_sample_index: List[int]
+    batch_sample_index: List[int]
+    buckets: List[List[BucketMergedState]]
+
+
+@dataclass
+class Bucket(Generic[T_batch_sample]):
+    key: Hashable
+    batch_size: int
+
+    samples: SavableSampleBuffer[T_batch_sample]
 
 
 class GroupBatchDataset(
     BaseSingleWrapperDataset[T_batch_sample, T_batch], Generic[T_batch_sample, T_batch]
 ):
     """This dataset wrapper transforms a dataset of samples into a dataset of batches, grouped
-    by some criterion. This will not have a correct length, as it depends on the grouping.
+    by some criterion. The length returned is the number of inner samples.
     An example use case is: Image-Text samples, which are to be grouped by the image size into three
     size categories (e.g. 128x128, 256x256, 512x512) for efficient augmentation and batching.
     """
 
     dataset: SavableDataset[T_batch_sample]
-    batch_size: int
-    group_criterion: Callable[[T_batch_sample], Hashable]
+    sample_group_key: Callable[[T_batch_sample], Tuple[Hashable, Optional[int]]]
     batcher: Callable[[List[T_batch_sample]], T_batch]
     drop_last: bool
     error_handler: Callable[[Exception, List[T_batch_sample]], None]
     worker_config: WorkerConfig
-    n_groups: int
-
-    _state_batches: List[Optional[Dict[Hashable, List[T_batch_sample]]]]
+    _group_key_sample_index: SampleIndex
+    _batch_sample_index: SampleIndex
+    _buckets: List[Dict[Hashable, Bucket[T_batch_sample]]]
 
     def __init__(
         self,
         dataset: SavableDataset[T_batch_sample],
-        batch_size: int,
-        group_criterion: Callable[[T_batch_sample], Hashable],
+        default_batch_size: Optional[int],
+        sample_group_key: Callable[[T_batch_sample], Tuple[Hashable, Optional[int]]],
         batcher: Callable[[List[T_batch_sample]], T_batch],
         *,
+        batcher_stateless: bool = False,
+        batcher_config: Optional[Union[Dict[str, Any], Callable[[], Dict[str, Any]]]] = None,
         drop_last: bool = False,
         error_handler: Callable[[Exception, List[T_batch_sample]], None] = log_exception,
         worker_config: WorkerConfig,
-        n_groups: int = 1,
     ):
         """Construct a GroupBatchDataset.
 
         Args:
             dataset: The input dataset to wrap
-            batch_size: The desired batch size. The last batch may be smaller.
-            group_criterion: Function which determines the group of a sample.
+            default_batch_size: Default batch size to use if not specified by the bucket function.
+            bucket: Function which determines the bucket of a sample.
             batcher: Function which combines separate samples into a single object. May raise
                 :exc:`megatron.energon.SkipSample` to skip a sample.
             drop_last: If True, the last batch is dropped if it is smaller than the batch size.
             error_handler: Handler for errors. Defaults to logging and ignoring the exception.
             worker_config: Configuration for the workers.
-            n_groups: Number of different groups. If not set properly, `len` might be less than the
-                actual number of samples yielded.
         """
         super().__init__(dataset)
-        self.batch_size = batch_size
-        self.group_criterion = group_criterion
+        self.default_batch_size = default_batch_size
+        self.sample_group_key = sample_group_key
         self.batcher = batcher
+        self.batcher_stateless = batcher_stateless
+        self.batcher_config = batcher_config
         self.drop_last = drop_last
         self.error_handler = error_handler
         self.worker_config = worker_config
-        self.n_groups = n_groups
-        self._state_batches = [{} for _ in range(max(self.worker_config.num_workers, 1))]
+        self._group_key_sample_index = SampleIndex(worker_config, src=self)
+        self._batch_sample_index = SampleIndex(worker_config, src=self)
+        self._buckets = [{} for _ in range(max(self.worker_config.num_workers, 1))]
+        assert not inspect.isgeneratorfunction(
+            batcher
+        ), f"Batcher {batcher} must not be a generator function for grouped batching."
 
     def __len__(self):
-        # This is only an approximation, since we don't know how many groups there are.
-        # Should always overestimate (might yield less than actual number of batches).
-        n_samples = len(self.dataset)
-        worker_groups = self.worker_config.num_workers * self.n_groups
-        n_samples_per_worker_floor = n_samples // worker_groups
-        remaining_n_sample_workers = n_samples % worker_groups
-        n_batches_per_worker_floor = n_samples_per_worker_floor // self.batch_size
-        if n_samples_per_worker_floor % self.batch_size != 0 and not self.drop_last:
-            n_batches_per_worker_floor += 1
-        # Correct number of batches for the workers which yield 1 more sample (to balance)
-        n_batches_per_worker_ceil = (n_samples_per_worker_floor + 1) // self.batch_size
-        if n_batches_per_worker_ceil % self.batch_size != 0 and not self.drop_last:
-            n_batches_per_worker_ceil += 1
-
-        return (
-            n_batches_per_worker_floor * (worker_groups - remaining_n_sample_workers)
-            + n_batches_per_worker_ceil * remaining_n_sample_workers
-        )
+        # Return an upper bound. This is for sure not correct.
+        return len(self.dataset)
 
     def __iter__(self) -> Iterator[T_batch]:
-        batches: Dict[Hashable, List[T_batch_sample]]
         worker_idx = self.worker_config.rank_worker_id()
+        buckets = self._buckets[worker_idx]
         # Cleanup other states
         for i in range(self.worker_config.num_workers):
             if i != worker_idx:
-                self._state_batches[i] = None
-        if self._state_batches[worker_idx] is None:
-            self._state_batches[worker_idx] = {}
-        batches = self._state_batches[worker_idx]
+                self._buckets[i].clear()
+
+        if buckets is None:
+            buckets = self._buckets[worker_idx] = dict()
+
+        # Load saved state if available
+        for bucket in buckets.values():
+            bucket.samples.worker_start()
+
+        def flush(bucket: Bucket[T_batch_sample]) -> Generator[T_batch, None, None]:
+            batch_items, sample_restore_keys = bucket.samples.flush()
+            try:
+                with self._batch_sample_index.ctx() as sample_idx:
+                    batch_sample = self.batcher(batch_items)
+                    assert not isinstance(
+                        batch_sample, Generator
+                    ), f"Batcher {self.batcher} returned a generator, which is not supported for grouped batching yet."
+                set_sample_restore_key(batch_sample, sample_idx, *sample_restore_keys, src=self)
+                yield batch_sample
+            except SkipSample:
+                pass
+            except SYSTEM_EXCEPTIONS:
+                raise FatalSampleError.from_sample(batch_items)
+            except Exception as e:
+                self.error_handler(e, batch_items)
+
+        # Add samples to the buckets
         for sample in self.dataset:
             try:
-                group = self.group_criterion(sample)
+                with self._group_key_sample_index.ctx():
+                    bucket_key, batch_size = self.sample_group_key(sample)
+                if batch_size is None:
+                    assert (
+                        self.default_batch_size is not None
+                    ), f"Got None batch size for group {bucket_key}, but no default batch size is set."
+                    batch_size = self.default_batch_size
             except SkipSample:
                 continue
             except SYSTEM_EXCEPTIONS:
@@ -137,73 +193,139 @@ class GroupBatchDataset(
             except Exception as e:
                 self.error_handler(e, [sample])
                 continue
-            batch_group = batches.get(group)
-            if batch_group is None:
-                batches[group] = batch_group = []
-            batch_group.append(sample)
-            if len(batch_group) == self.batch_size:
-                try:
-                    yield self.batcher(batch_group)
-                except SkipSample:
-                    pass
-                except SYSTEM_EXCEPTIONS:
-                    raise FatalSampleError.from_sample(batch_group)
-                except Exception as e:
-                    self.error_handler(e, batch_group)
-                del batches[group]
+            bucket = buckets.get(bucket_key)
+            if bucket is None:
+                buckets[bucket_key] = bucket = Bucket(
+                    key=bucket_key,
+                    batch_size=batch_size,
+                    samples=SavableSampleBuffer(self.dataset, self.worker_config),
+                )
+            else:
+                assert bucket.key == bucket_key
+                assert (
+                    bucket.batch_size == batch_size
+                ), f"Got different batch size for group {bucket_key}: {bucket.batch_size} != {batch_size}."
+            bucket.samples.append(sample)
+            if len(bucket.samples) >= bucket.batch_size:
+                yield from flush(bucket)
+        # Flush out last samples
         if not self.drop_last:
-            for batch in batches.values():
-                try:
-                    yield self.batcher(batch)
-                except SkipSample:
-                    pass
-                except SYSTEM_EXCEPTIONS:
-                    raise FatalSampleError.from_sample(batch)
-                except Exception as e:
-                    self.error_handler(e, batch)
-        self._state_batches[worker_idx] = None
+            for bucket in buckets.values():
+                if len(bucket.samples) > 0:
+                    yield from flush(bucket)
+        # Clear the buckets
+        self._buckets[worker_idx].clear()
 
     def save_state(self) -> GroupBatchState:
+        rank = self.worker_config.rank_worker_id()
         return GroupBatchState.extend(
             super().save_state(),
-            batches=dict(self._state_batches[self.worker_config.rank_worker_id()]),
+            bucket_sample_index=self._group_key_sample_index.save_state(),
+            batch_sample_index=self._batch_sample_index.save_state(),
+            buckets=(
+                [
+                    BucketState(
+                        key=key,
+                        batch_size=bucket.batch_size,
+                        samples=bucket.samples.save_state(),
+                    )
+                    for key, bucket in self._buckets[rank].items()
+                ]
+                if self._buckets[rank] is not None
+                else []
+            ),
         )
 
-    def merge_states(self, states: List[GroupBatchState]) -> GroupBatchMergedState:
+    def merge_states(self, states: List[Optional[GroupBatchState]]) -> GroupBatchMergedState:
         assert all(s is None or isinstance(s, GroupBatchState) for s in states)
         return GroupBatchMergedState.extend(
             super().merge_states(states),
-            batches=[{} if s is None else s.batches for s in states],
+            bucket_sample_index=self._group_key_sample_index.merge_states(
+                [0 if s is None else s.bucket_sample_index for s in states]
+            ),
+            batch_sample_index=self._batch_sample_index.merge_states(
+                [0 if s is None else s.batch_sample_index for s in states]
+            ),
+            buckets=[(state.buckets if state else []) for state in states],
         )
 
-    def restore_state(self, state: GroupBatchMergedState) -> None:
+    def restore_state(self, state: Optional[GroupBatchMergedState]) -> None:
         super().restore_state(state)
         if state is None:
-            self._state_batches = [{} for _ in range(max(self.worker_config.num_workers, 1))]
+            self._buckets = [{} for _ in range(max(self.worker_config.num_workers, 1))]
         else:
             assert isinstance(state, GroupBatchMergedState)
-            self._state_batches = state.batches
+            self._group_key_sample_index.restore_state(state.bucket_sample_index)
+            self._batch_sample_index.restore_state(state.batch_sample_index)
+            for worker_idx, (buckets_state, buckets) in enumerate(
+                zip(state.buckets, self._buckets)
+            ):
+                buckets.clear()
+                if buckets_state is None:
+                    continue
+                else:
+                    for bucket_state in buckets_state:
+                        buckets[bucket_state.key] = Bucket(
+                            key=bucket_state.key,
+                            batch_size=bucket_state.batch_size,
+                            samples=SavableSampleBuffer(self.dataset, self.worker_config),
+                        )
+                        buckets[bucket_state.key].samples.restore_state(
+                            SampleBufferMergedState(
+                                buffer=[
+                                    (
+                                        []
+                                        if gen_worker_idx == worker_idx
+                                        else bucket_state.samples.buffer
+                                    )
+                                    for gen_worker_idx in range(
+                                        max(self.worker_config.num_workers, 1)
+                                    )
+                                ]
+                            )
+                        )
 
     def can_restore_sample(self) -> bool:
-        return False
+        return self.batcher_stateless and self.dataset.can_restore_sample()
+
+    def assert_can_restore(self) -> None:
+        assert (
+            self.batcher_stateless
+        ), f"Batcher {self.batcher} must be stateless to restore samples"
+        self.dataset.assert_can_restore()
 
     def restore_sample(self, index: Tuple[Union[str, int, tuple], ...]) -> T_batch:
-        # TODO: We'd need to store multiple indices to restore a batch
-        # Also, returned elements don't support __restore_key__. Would need extension.
-        raise NotImplementedError("GroupBatchDataset does not support random access.")
+        self.assert_can_restore()
+        id, sample_idx, *sample_restore_keys = index
+        assert id == type(self).__name__
+        batch = [self.dataset.restore_sample(inner_idx) for inner_idx in sample_restore_keys]
+        with self._batch_sample_index.ctx(sample_idx):
+            batch_sample = self.batcher(batch)
+        set_sample_restore_key(batch_sample, sample_idx, *sample_restore_keys, src=self)
+        return batch_sample
 
     def config(self) -> Dict[str, Any]:
         return {
             "type": type(self).__qualname__,
-            "dataset": self.dataset.config(),
-            "batch_size": self.batch_size,
-            "group_criterion": self._function_config(self.group_criterion),
+            "bucket": self._function_config(self.sample_group_key),
             "batcher": self._function_config(self.batcher),
+            **(
+                {
+                    "batcher_config": (
+                        self.batcher_config()
+                        if callable(self.batcher_config)
+                        else self.batcher_config
+                    )
+                }
+                if self.batcher_config
+                else {}
+            ),
+            "batcher_stateless": self.batcher_stateless,
             "drop_last": self.drop_last,
             "error_handler": self._function_config(self.error_handler),
             "worker_config": self.worker_config.config(),
-            "n_groups": self.n_groups,
+            "dataset": self.dataset.config(),
         }
 
     def __str__(self):
-        return f"GroupBatchDataset(batch_size={self.batch_size}, group_criterion={self.group_criterion}, batcher={self.batcher}, drop_last={self.drop_last}, error_handler={self.error_handler}, worker_config={self.worker_config}, n_groups={self.n_groups}, dataset={self.dataset})"
+        return f"GroupBatchDataset(bucket={self.sample_group_key}, batcher={self.batcher}, drop_last={self.drop_last}, dataset={self.dataset})"

--- a/src/megatron/energon/wrappers/packing_dataset.py
+++ b/src/megatron/energon/wrappers/packing_dataset.py
@@ -164,7 +164,7 @@ class PackingDataset(
                 return False
         return True
 
-    def __iter__(self) -> Iterator[T_sample]:
+    def __iter__(self) -> Iterator[T_batch_sample]:
         worker_idx = self.worker_config.rank_worker_id()
         pre_packing_lengths = self._pre_packing_lengths[worker_idx]
         # The source dataset
@@ -204,7 +204,7 @@ class PackingDataset(
                     self._pre_packing_buffer.extend(pre_pack)
                     pre_packing_lengths.append(len(pre_pack))
 
-        def next_final_pack():
+        def next_final_pack() -> Generator[T_batch_sample, None, None]:
             """Yield the next packs from the buffer. The final packer is called on the fly."""
 
             pack = list(self._pre_packing_buffer[: pre_packing_lengths[0]])
@@ -217,7 +217,7 @@ class PackingDataset(
                 if isinstance(final_packed_sample, Generator):
                     assert inspect.isgeneratorfunction(
                         self.final_packer
-                    ), f"Generator in {self.map_fn} but not marked as such."
+                    ), f"Generator in {self.final_packer} but not marked as such."
                     for pack_sub_idx, (pack_idx, inner_batch_sample) in enumerate(
                         self._final_packing_sample_index.iter_ctx(final_packed_sample, pack_idx)
                     ):

--- a/src/megatron/energon/wrappers/packing_dataset.py
+++ b/src/megatron/energon/wrappers/packing_dataset.py
@@ -348,7 +348,7 @@ class PackingDataset(
         if isinstance(final_pack, Generator):
             assert inspect.isgeneratorfunction(
                 self.final_packer
-            ), f"Generator in {self.map_fn} but not marked as such."
+            ), f"Generator in {self.final_packer} but not marked as such."
             for cur_batch_sub_idx, (pack_idx, inner_batch_sample) in enumerate(
                 self._final_packing_sample_index.iter_ctx(final_pack, pack_idx)
             ):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1510,6 +1510,25 @@ class TestDataset(unittest.TestCase):
                 else:
                     assert False
 
+        worker_config = WorkerConfig(rank=0, world_size=1, num_workers=0)
+        loader = get_savable_loader(
+            get_train_dataset(
+                self.dataset_path,
+                batch_size=None,
+                worker_config=worker_config,
+                shuffle_buffer_size=None,
+                max_samples_per_sequence=None,
+                task_encoder=GroupingTaskEncoder(),
+            ),
+            worker_config=worker_config,
+            checkpoint_every_min_n_samples=1,
+            checkpoint_every_sec=0,
+            n_checkpoints=4,
+        )
+        batches = list(zip(range(40), loader))
+        print([batch.__key__ for idx, batch in batches])
+        assert all(all(key == batch.caption[0] for key in batch.caption) for idx, batch in batches)
+
         worker_config_r0 = WorkerConfig(rank=0, world_size=2, num_workers=2)
 
         loader_r0 = get_savable_loader(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -15,7 +15,7 @@ import unittest
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Tuple, Type, Union
+from typing import Any, Dict, Hashable, List, Tuple, Type, Union
 
 import numpy as np
 import torch
@@ -1492,6 +1492,83 @@ class TestDataset(unittest.TestCase):
         ] == [[16, 1], [16, 1], [4, 16], [4, 16], [1, 4], [1, 4], [16, 1], [16, 1]]
 
         assert all(s0.__key__ == s1.__key__ for s0, s1 in zip(samples_r0_cmp, samples_r0_restored))
+
+    def test_group_batch(self):
+        class GroupingTaskEncoder(
+            TaskEncoder[CaptioningSample, CaptioningSample, CaptioningSample, CaptioningSample]
+        ):
+            @stateless
+            def encode_sample(self, sample: CaptioningSample) -> CaptioningSample:
+                sample.caption = sample.__key__.split("/")[-2]
+                return sample
+
+            def batch_group_criterion(self, sample: CaptioningSample) -> Tuple[Hashable, int]:
+                if sample.caption == "data-0.tar":
+                    return "shard1", 4
+                elif sample.caption == "data-1.tar":
+                    return "shard2", 8
+                else:
+                    assert False
+
+        worker_config_r0 = WorkerConfig(rank=0, world_size=2, num_workers=2)
+
+        loader_r0 = get_savable_loader(
+            get_train_dataset(
+                self.dataset_path,
+                batch_size=None,
+                worker_config=worker_config_r0,
+                shuffle_buffer_size=None,
+                max_samples_per_sequence=None,
+                task_encoder=GroupingTaskEncoder(),
+            ),
+            worker_config=worker_config_r0,
+            checkpoint_every_min_n_samples=1,
+            checkpoint_every_sec=0,
+            n_checkpoints=4,
+        )
+
+        batches = list(zip(range(40), loader_r0))
+
+        print([batch.__key__ for idx, batch in batches])
+
+        assert all(all(key == batch.caption[0] for key in batch.caption) for idx, batch in batches)
+
+        state = loader_r0.save_state_rank()
+
+        cmp_samples = list(zip(range(40, 80), loader_r0))
+        print([batch.__key__ for idx, batch in cmp_samples])
+
+        loader_r0 = get_savable_loader(
+            get_train_dataset(
+                self.dataset_path,
+                batch_size=None,
+                worker_config=worker_config_r0,
+                shuffle_buffer_size=None,
+                max_samples_per_sequence=None,
+                task_encoder=GroupingTaskEncoder(),
+            ),
+            worker_config=worker_config_r0,
+            checkpoint_every_min_n_samples=1,
+            checkpoint_every_sec=0,
+            n_checkpoints=4,
+        )
+        loader_r0.restore_state_rank(state)
+
+        cmp_samples_rest = list(zip(range(40, 80), loader_r0))
+        print([batch.__key__ for idx, batch in cmp_samples_rest])
+
+        assert len(cmp_samples) == len(cmp_samples_rest)
+        assert all(
+            len(cmp_sample.caption) == len(cmp_sample_rest.caption)
+            for (idx, cmp_sample), (idx, cmp_sample_rest) in zip(cmp_samples, cmp_samples_rest)
+        )
+        assert all(
+            all(
+                cmp_cap == cmp_cap_rest
+                for cmp_cap, cmp_cap_rest in zip(cmp_sample.caption, cmp_sample_rest.caption)
+            )
+            for (idx, cmp_sample), (idx, cmp_sample_rest) in zip(cmp_samples, cmp_samples_rest)
+        )
 
     def test_debug_dataset(self):
         torch.manual_seed(42)


### PR DESCRIPTION
Fixes the grouped batching to support all saving/restoring features.

BREAKING CHANGE:
* The previous (hopefully unused) interface of `TaskEncoder.batch_group_criterion` is incompatible
* Save format of the `SavableSampleBuffer` changed. It erronously previously saved the inner dataset state additionally, resulting in duplicate saving and restoring. Thus, old checkpoints will be incompatible