### PR TITLE
Improve distribution of samples to workers when using many datasets

### DIFF
--- a/src/megatron/energon/flavors/base_dataset.py
+++ b/src/megatron/energon/flavors/base_dataset.py
@@ -373,7 +373,10 @@ class BaseCoreDatasetFactory(Generic[T_sample], ABC):
     subflavors: Dict[str, Any]
 
     @abstractmethod
-    def build(self) -> SavableDataset[T_sample]: ...
+    def build(self, worker_rotation_offset: int = 0) -> SavableDataset[T_sample]: ...
+
+    @abstractmethod
+    def __len__(self) -> int: ...
 
 
 def add_sample_restore_key(

--- a/src/megatron/energon/flavors/base_dataset.py
+++ b/src/megatron/energon/flavors/base_dataset.py
@@ -376,7 +376,9 @@ class BaseCoreDatasetFactory(Generic[T_sample], ABC):
     def build(self, worker_rotation_offset: int = 0) -> SavableDataset[T_sample]: ...
 
     @abstractmethod
-    def __len__(self) -> int: ...
+    def __len__(self) -> int:
+        """Returns the length of the dataset across all ranks."""
+        ...
 
 
 def add_sample_restore_key(

--- a/src/megatron/energon/flavors/webdataset/base_webdataset.py
+++ b/src/megatron/energon/flavors/webdataset/base_webdataset.py
@@ -112,7 +112,10 @@ class BaseWebdatasetFactory(
         self.part_filter = part_filter
         self.handler = handler
 
-    def build(self) -> SavableDataset[T_sample]:
+    def __len__(self) -> int:
+        return sum(shard.count for shard in self.shards)
+
+    def build(self, worker_rotation_offset: int = 0) -> SavableDataset[T_sample]:
         if self.parallel_shard_iters is None:
             if self.training:
                 # 16 seems to be a good choice since we don't want too many file handles open
@@ -126,6 +129,7 @@ class BaseWebdatasetFactory(
             [(shard,) for shard in self.shards],
             self.worker_config,
             max_samples_per_sequence=self.max_samples_per_sequence,
+            rotation_offset=worker_rotation_offset,
         )
         for rank_idx, inner_shards in enumerate(rank_shards):
             shards_text = ", ".join(

--- a/src/megatron/energon/flavors/webdataset/joined_webdataset.py
+++ b/src/megatron/energon/flavors/webdataset/joined_webdataset.py
@@ -144,7 +144,10 @@ class JoinedWebdatasetFactory(
         self.join_method = join_method
         self.handler = handler
 
-    def build(self) -> SavableDataset[T_sample]:
+    def __len__(self) -> int:
+        return sum(shard.count for shard in self.inner_datasets[0].shards)
+
+    def build(self, worker_rotation_offset: int = 0) -> SavableDataset[T_sample]:
         if self.parallel_shard_iters is None:
             if self.training:
                 # 16 seems to be a good choice since we don't want too many file handles open
@@ -158,6 +161,7 @@ class JoinedWebdatasetFactory(
             self.shards,
             self.worker_config,
             max_samples_per_sequence=self.max_samples_per_sequence,
+            rotation_offset=worker_rotation_offset,
         )
 
         for rank_idx, shards in enumerate(rank_shards):

--- a/src/megatron/energon/flavors/webdataset/sharder.py
+++ b/src/megatron/energon/flavors/webdataset/sharder.py
@@ -212,7 +212,7 @@ class Sharder:
             if global_worker_idx >= num_prev_workers:
                 local_rank_worker_sample_offsets.append(cur_offset)
 
-            if global_worker_idx >= num_prev_workers + num_workers + 1:
+            if global_worker_idx >= num_prev_workers + num_workers:
                 break
 
             if (

--- a/src/megatron/energon/flavors/webdataset/sharder.py
+++ b/src/megatron/energon/flavors/webdataset/sharder.py
@@ -208,7 +208,7 @@ class Sharder:
         # and as global offsets we get [0, 1, 3, 5, 7, 9, 10]
 
         local_rank_worker_sample_offsets = []
-        for global_worker_idx in range(global_workers):
+        for global_worker_idx in range(global_workers + 1):
             if global_worker_idx >= num_prev_workers:
                 local_rank_worker_sample_offsets.append(cur_offset)
 

--- a/src/megatron/energon/flavors/webdataset/sharder.py
+++ b/src/megatron/energon/flavors/webdataset/sharder.py
@@ -67,8 +67,7 @@ class Sharder:
     ) -> List[Sequence[ShardInfo]]:
         """
         Splits the shards into multiple lists based on the start/end sample offsets.
-        of the first shard emitted, the last offset is the end of the last shard emitted.
-        (i.e. number of shards emitted is `len(offsets) - 1`)
+        The splitting is done across shard boundaries and multiple shards can be returned.
 
         Args:
             shards: The source shards

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -580,7 +580,7 @@ class TestDataset(unittest.TestCase):
         assert len(val_dataset) == 8
         assert len(val_loader) == 8
         assert len(list(val_loader)) == 8
-        assert [len(entry.__key__) for entry in val_loader] == [11, 11, 11, 11, 2, 2, 1, 1]
+        assert [len(entry.__key__) for entry in val_loader] == [11, 11, 11, 11, 2, 1, 2, 1]
         assert sum(len(entry.__key__) for entry in val_loader) == 50
 
     def test_multirank_dataset(self):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -580,7 +580,7 @@ class TestDataset(unittest.TestCase):
         assert len(val_dataset) == 8
         assert len(val_loader) == 8
         assert len(list(val_loader)) == 8
-        assert [len(entry.__key__) for entry in val_loader] == [11, 11, 11, 11, 1, 2, 1, 2]
+        assert [len(entry.__key__) for entry in val_loader] == [11, 11, 11, 11, 2, 2, 1, 1]
         assert sum(len(entry.__key__) for entry in val_loader) == 50
 
     def test_multirank_dataset(self):
@@ -625,7 +625,7 @@ class TestDataset(unittest.TestCase):
         assert len(list(val_loader0b11)) == 4
         keys0b11 = set(key for entry in val_loader0b11 for key in entry.__key__)
         print([len(entry.__key__) for entry in val_loader0b11])
-        assert [len(entry.__key__) for entry in val_loader0b11] == [11, 11, 1, 2]
+        assert [len(entry.__key__) for entry in val_loader0b11] == [11, 11, 2, 1]
         assert len(keys0b11) == 25
 
         assert keys0b11 == keys0
@@ -652,7 +652,7 @@ class TestDataset(unittest.TestCase):
         assert len(list(val_loader1b11)) == 4
         keys1b11 = set(key for entry in val_loader1b11 for key in entry.__key__)
         print([len(entry.__key__) for entry in val_loader1b11])
-        assert [len(entry.__key__) for entry in val_loader1b11] == [11, 11, 1, 2]
+        assert [len(entry.__key__) for entry in val_loader1b11] == [11, 11, 2, 1]
         assert len(keys1b11) == 25
         assert keys1b11.isdisjoint(keys0b11)
 

--- a/tests/test_metadataset.py
+++ b/tests/test_metadataset.py
@@ -476,7 +476,8 @@ class TestDataset(unittest.TestCase):
                     18,
                 ]
             elif num_workers == 30:
-                # This should match the pattern of the first 40 items of a magic sequence of length 60
+                # This should match the pattern of the first 40 items of a generalized bit
+                # reversal sequence of length 60.
                 # Given 4 * 55 = 220 samples modulo 60 workers, is 40 remaining samples
                 assert list(samples_per_global_worker.values()) == [
                     4,

--- a/tests/test_metadataset.py
+++ b/tests/test_metadataset.py
@@ -462,21 +462,24 @@ class TestDataset(unittest.TestCase):
             # Check the sample assignnent is balanced across all global workers
             if num_workers == 6:
                 assert list(samples_per_global_worker.values()) == [
-                    19,
-                    19,
-                    19,
+                    19,  # rank 0
                     19,
                     18,
                     18,
                     18,
                     18,
+                    19,  # rank 1
+                    19,
                     18,
                     18,
                     18,
                     18,
                 ]
             elif num_workers == 30:
-                assert list(samples_per_global_worker.values()) == [4] * 40 + [3] * 20
+                assert (
+                    list(samples_per_global_worker.values())
+                    == [4] * 20 + [3] * 10 + [4] * 20 + [3] * 10
+                )
 
     def test_save_restore_state_train(self):
         torch.manual_seed(42)

--- a/tests/test_metadataset.py
+++ b/tests/test_metadataset.py
@@ -463,23 +463,83 @@ class TestDataset(unittest.TestCase):
             if num_workers == 6:
                 assert list(samples_per_global_worker.values()) == [
                     19,  # rank 0
+                    18,
+                    18,
                     19,
-                    18,
-                    18,
                     18,
                     18,
                     19,  # rank 1
+                    18,
+                    18,
                     19,
-                    18,
-                    18,
                     18,
                     18,
                 ]
             elif num_workers == 30:
-                assert (
-                    list(samples_per_global_worker.values())
-                    == [4] * 20 + [3] * 10 + [4] * 20 + [3] * 10
-                )
+                # This should match the pattern of the first 40 items of a magic sequence of length 60
+                # Given 4 * 55 = 220 samples modulo 60 workers, is 40 remaining samples
+                assert list(samples_per_global_worker.values()) == [
+                    4,
+                    4,
+                    4,
+                    4,
+                    3,
+                    4,
+                    3,
+                    4,
+                    4,
+                    4,
+                    3,
+                    4,
+                    3,
+                    4,
+                    3,
+                    4,
+                    4,
+                    4,
+                    4,
+                    3,
+                    4,
+                    3,
+                    4,
+                    4,
+                    4,
+                    3,
+                    4,
+                    3,
+                    4,
+                    3,
+                    4,
+                    4,
+                    4,
+                    4,
+                    3,
+                    4,
+                    3,
+                    4,
+                    4,
+                    4,
+                    3,
+                    4,
+                    3,
+                    4,
+                    3,
+                    4,
+                    4,
+                    4,
+                    4,
+                    3,
+                    4,
+                    3,
+                    4,
+                    4,
+                    4,
+                    3,
+                    4,
+                    3,
+                    4,
+                    3,
+                ]
 
     def test_save_restore_state_train(self):
         torch.manual_seed(42)

--- a/tests/test_metadataset.py
+++ b/tests/test_metadataset.py
@@ -26,6 +26,7 @@ from megatron.energon import (
     load_dataset,
 )
 from megatron.energon.flavors.webdataset import MAIN_FOLDER_NAME
+from megatron.energon.wrappers.blend_dataset import BlendDataset
 
 
 def _norng_state(state):
@@ -417,6 +418,65 @@ class TestDataset(unittest.TestCase):
         assert len(val_order1) == 110
         print(Counter(val_order1))
         assert all(v == 1 for v in Counter(val_order1).values())
+
+    def test_worker_sample_balance(self):
+        torch.manual_seed(42)
+
+        for num_workers in [6, 30]:
+            samples_per_global_worker = Counter()
+
+            for rank in range(2):
+                wc = WorkerConfig(
+                    rank=rank,
+                    world_size=2,
+                    num_workers=num_workers,
+                )
+
+                train_dataset = get_train_dataset(
+                    self.nested_mds_path,
+                    worker_config=wc,
+                    batch_size=1,
+                    shuffle_buffer_size=None,
+                    max_samples_per_sequence=None,
+                )
+
+                blend_dataset = train_dataset.dataset.dataset.dataset
+                assert isinstance(blend_dataset, BlendDataset)
+
+                ds_weights = blend_dataset.dataset_weights
+                assert len(ds_weights) == 4  # 4 datasets
+
+                # We are now going to count the number of samples that was assigned to each
+                # globally unique worker. This corresponds to the shard_ranges that energon
+                # prints out when the dataset is built.
+
+                for ds, w in ds_weights:
+                    ds_shards = ds.dataset.shards
+                    assert len(ds_shards) == num_workers
+
+                    for worker_idx, shards in enumerate(ds_shards):
+                        samples_per_global_worker[(rank, worker_idx)] += sum(
+                            [shard[0].count for shard in shards]
+                        )
+
+            # Check the sample assignnent is balanced across all global workers
+            if num_workers == 6:
+                assert list(samples_per_global_worker.values()) == [
+                    19,
+                    19,
+                    19,
+                    19,
+                    18,
+                    18,
+                    18,
+                    18,
+                    18,
+                    18,
+                    18,
+                    18,
+                ]
+            elif num_workers == 30:
+                assert list(samples_per_global_worker.values()) == [4] * 40 + [3] * 20
 
     def test_save_restore_state_train(self):
         torch.manual_seed(42)


### PR DESCRIPTION
When blending many datasets together, the samples of each dataset will be distributed across all workers available globally.
Since the number of samples is typically not divisible by the number of workers, some workers will obtain more samples than others.
In the case of many datasets, this imbalance may be amplified if each dataset assigns the remainder samples to the same workers. This is leading to some workers having significantly more samples than others.

This PR mitigates this effect by shifting the assignment of samples to workers in a way that minimizes the imbalance. To that end, each dataset starts assigning samples to workers at an offset that depends on the lengths of the previous datasets, essentially filling up workers equally. 
The order in which the filling up happens, is not left-to-right, but given by a divide-and-interleave algorithm that corresponds to a generalized bit reversal permutation. This helps balance out the remainder samples across ranks in a rank-count-independent way.

BREAKING CHANGE: By improved balancing, the data ordering will not be exactly the same as before. The difference is more severe when many datasets are blended.