### PR TITLE
feat: Use Multi-Storage Client in Energon

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "tqdm",
   "webdataset",
   "s3fs",
+  "multi-storage-client>=0.13",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "tqdm",
   "webdataset",
   "s3fs",
-  "multi-storage-client>=0.13",
+  "multi-storage-client>=0.13.0",
 ]
 
 [project.optional-dependencies]

--- a/src/megatron/energon/epathlib/epath.py
+++ b/src/megatron/energon/epathlib/epath.py
@@ -53,7 +53,7 @@ class MSCFileSystem:
 
     def makedirs(self, path: str, exist_ok: bool = False):
         pass
-    
+
     def __eq__(self, other):
         if not isinstance(other, MSCFileSystem):
             return False

--- a/tests/test_epathlib.py
+++ b/tests/test_epathlib.py
@@ -114,9 +114,9 @@ class TestEPath(unittest.TestCase):
 
         p4 = p3.parent / "../bla/bla/bla/../../../no/../subpath2.txt"
         assert str(p4) == "rclone://s3/subpath2.txt", str(p4)
-    
+
     def test_multi_storage_client(self):
-        """ Test the Multi-Storage Client integration """
+        """Test the Multi-Storage Client integration"""
         # Test path handling
         p = EPath("msc://default/etc/resolv.conf")
         assert str(p) == "msc://default/etc/resolv.conf", str(p)
@@ -130,12 +130,12 @@ class TestEPath(unittest.TestCase):
         assert p3.is_dir()
         for i in p3.glob("*.conf"):
             assert str(i).endswith(".conf")
-        
+
         # Test open file
         assert p.size() > 0
         with p.open("r") as fp:
             assert len(fp.read()) > 0
-        
+
         # Test move and delete
         p4 = EPath("msc://default/tmp/random_file_0001")
         p4.unlink()

--- a/tests/test_epathlib.py
+++ b/tests/test_epathlib.py
@@ -114,6 +114,42 @@ class TestEPath(unittest.TestCase):
 
         p4 = p3.parent / "../bla/bla/bla/../../../no/../subpath2.txt"
         assert str(p4) == "rclone://s3/subpath2.txt", str(p4)
+    
+    def test_multi_storage_client(self):
+        """ Test the Multi-Storage Client integration """
+        # Test path handling
+        p = EPath("msc://default/etc/resolv.conf")
+        assert str(p) == "msc://default/etc/resolv.conf", str(p)
+        assert p.is_file()
+
+        p2 = p / ".." / "hosts"
+        assert str(p2) == "msc://default/etc/hosts", str(p2)
+
+        # Test glob
+        p3 = EPath("msc://default/etc/")
+        assert p3.is_dir()
+        for i in p3.glob("*.conf"):
+            assert str(i).endswith(".conf")
+        
+        # Test open file
+        assert p.size() > 0
+        with p.open("r") as fp:
+            assert len(fp.read()) > 0
+        
+        # Test move and delete
+        p4 = EPath("msc://default/tmp/random_file_0001")
+        p4.unlink()
+        with p4.open("w") as fp:
+            fp.write("*****")
+        assert p4.is_file()
+        p5 = EPath("msc://default/tmp/random_file_0002")
+        p5.unlink()
+        assert p5.is_file() is False
+        p4.move(p5)
+        assert p5.is_file()
+        assert p4.is_file() is False
+        p5.unlink()
+        assert p5.is_file() is False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add the support of [Multi-Storage Client ](https://github.com/NVIDIA/multi-storage-client) into Megatron-Energon. With this change, the EPath can open an `msc://` URL and read from various object stores.

> The Multi-Storage Client (MSC) is a unified high-performance Python client for object and file stores such as AWS S3, Azure Blob Storage, Google Cloud Storage (GCS), NVIDIA AIStore, Oracle Cloud Infrastructure (OCI) Object Storage, POSIX file systems, and more.

Here is an example of how to access S3 via MSC in Energon.

**Create MSC Config**
```yaml
# File: ~/.msc_config.yaml
profiles:
  s3-iad-webdataset:
    credentials_provider:
      type: S3Credentials
      options:
        access_key: *****
        secret_key: *****
    storage_provider:
      type: s3
      options:
        base_path: mybucket
        region_name: us-east-1
```

**Prepare Dataset**
```
$ energon prepare msc://s3-iad-webdataset/
```

**Read Dataset**
```python
def test_msc_url():
    dataset_name = "msc://s3-iad-webdataset/"

    train_loader = get_loader(get_train_dataset(
        dataset_name,
        batch_size=64,
        shuffle_buffer_size=None,
        max_samples_per_sequence=None,
    ))

    train_loader = iter(train_loader)
```