### PR TITLE
Release 5.1.0

### DIFF
--- a/docs/source/internals/contrib_guidelines.md
+++ b/docs/source/internals/contrib_guidelines.md
@@ -13,9 +13,8 @@ If you want to contribute to this repository please adhere to the following guid
   and end up in this documentation
 - Breaking changes should be marked in the message of pull requests:
   - `CHECKPOINT BREAKING CHANGE`: When the save/restore structure changed incompatibly (check test `test_metadataset:TestDataset.test_save_restore_state_train`)
-  - `RANDOMNESS BREAKING CHANGE`: When the randomness changed (check tests `test_dataset:TestDataset.test_current_batch_index_generator`, `test_dataset:TestDataset.test_current_batch_index`, maybe more)
+  - `ITERATION ORDER BREAKING CHANGE`: When the order of iterating samples changed, i.e. experiments would not be exactly reproducible (check tests `test_dataset:TestDataset.test_current_batch_index_generator`, `test_dataset:TestDataset.test_current_batch_index`, maybe more)
   - `API BREAKING CHANGE`: When the external programming api changed incompatibly
   - `DATASET CONFIG BREAKING CHANGE`: When the dataset config (`.nv-meta` folder) changed incompatibly
   - `METADATASET CONFIG BREAKING CHANGE`: When the metadataset config changed
 - In a release, all breaking changes except checkpoint lead to a new major version.
--


### PR DESCRIPTION
New Features:
* Reduce checkpoint size, by reproducing the pending shards instead of storing them (@voegtlel, #49, CHECKPOINT BREAKING CHANGE)