### PR TITLE
Bugfix/preparing crude

### DIFF
--- a/src/megatron/energon/tools/prepare.py
+++ b/src/megatron/energon/tools/prepare.py
@@ -13,7 +13,7 @@ import click
 import yaml
 
 from megatron.energon.epathlib import EPath
-from megatron.energon.flavors import BaseWebdatasetFactory
+from megatron.energon.flavors import BaseWebdatasetFactory, CrudeWebdataset
 from megatron.energon.flavors.base_dataset import Sample
 from megatron.energon.flavors.webdataset import MAIN_FOLDER_NAME
 
@@ -281,25 +281,25 @@ def command(
         click.echo("The sample type you selected:\n")
         click.echo(sample_type_source)
 
-        dataset_definition = {
-            "sample_type": {
-                "__module__": "megatron.energon",
-                "__class__": cls.__name__,
-            }
-        }
-
         if cls == CrudeSampleDummy:
-            from megatron.energon.flavors import CrudeWebdataset
-
             click.echo(
                 "CrudeWebdataset does not need a field map. You will need to provide a `Cooker` for your dataset samples in your `TaskEncoder`."
             )
             click.echo(
                 "Furthermore, you might want to add `subflavors` in your meta dataset specification."
             )
-            dataset_definition = dataset_definition["sample_type"]
-            dataset_definition["__class__"] = CrudeWebdataset.__name__
+            dataset_definition = {
+                "__module__": "megatron.energon",
+                "__class__": CrudeWebdataset.__name__,
+            }
         else:
+            dataset_definition = {
+                "sample_type": {
+                    "__module__": "megatron.energon",
+                    "__class__": cls.__name__,
+                }
+            }
+
             if not allow_interactive_field_map:
                 click.echo(
                     "You cannot set a field_map for this dataset. You will need a sample_loader."

--- a/src/megatron/energon/tools/prepare.py
+++ b/src/megatron/energon/tools/prepare.py
@@ -290,6 +290,7 @@ def command(
 
         if cls == CrudeSampleDummy:
             from megatron.energon.flavors import CrudeWebdataset
+
             click.echo(
                 "CrudeWebdataset does not need a field map. You will need to provide a `Cooker` for your dataset samples in your `TaskEncoder`."
             )
@@ -297,7 +298,7 @@ def command(
                 "Furthermore, you might want to add `subflavors` in your meta dataset specification."
             )
             dataset_definition = dataset_definition["sample_type"]
-            dataset_definition["__class__"]=CrudeWebdataset.__name__
+            dataset_definition["__class__"] = CrudeWebdataset.__name__
         else:
             if not allow_interactive_field_map:
                 click.echo(

--- a/src/megatron/energon/tools/prepare.py
+++ b/src/megatron/energon/tools/prepare.py
@@ -289,7 +289,7 @@ def command(
         }
 
         if cls == CrudeSampleDummy:
-            from megatron.energon import CrudeWebdataset
+            from megatron.energon.flavors import CrudeWebdataset
             click.echo(
                 "CrudeWebdataset does not need a field map. You will need to provide a `Cooker` for your dataset samples in your `TaskEncoder`."
             )

--- a/src/megatron/energon/tools/prepare.py
+++ b/src/megatron/energon/tools/prepare.py
@@ -12,6 +12,7 @@ from typing import Any, List, Optional, Type
 import click
 import yaml
 
+from megatron.energon import CrudeWebdataset
 from megatron.energon.epathlib import EPath
 from megatron.energon.flavors import BaseWebdatasetFactory
 from megatron.energon.flavors.base_dataset import Sample
@@ -295,6 +296,8 @@ def command(
             click.echo(
                 "Furthermore, you might want to add `subflavors` in your meta dataset specification."
             )
+            dataset_definition = dataset_definition["sample_type"]
+            dataset_definition["__class__"]=CrudeWebdataset.__name__
         else:
             if not allow_interactive_field_map:
                 click.echo(

--- a/src/megatron/energon/tools/prepare.py
+++ b/src/megatron/energon/tools/prepare.py
@@ -12,7 +12,6 @@ from typing import Any, List, Optional, Type
 import click
 import yaml
 
-from megatron.energon import CrudeWebdataset
 from megatron.energon.epathlib import EPath
 from megatron.energon.flavors import BaseWebdatasetFactory
 from megatron.energon.flavors.base_dataset import Sample
@@ -290,6 +289,7 @@ def command(
         }
 
         if cls == CrudeSampleDummy:
+            from megatron.energon import CrudeWebdataset
             click.echo(
                 "CrudeWebdataset does not need a field map. You will need to provide a `Cooker` for your dataset samples in your `TaskEncoder`."
             )


### PR DESCRIPTION
This fixes a `dataset.yaml` that was created incorrectly. closes #54 
Before:
```yaml
sample_type:
  __module__: megatron.energon
  __class__: CrudeSampleDummy
```

After:
```yaml
__module__: megatron.energon
__class__: CrudeWebdataset
```
