### PR TITLE
Allow float for repetitions

### DIFF
--- a/src/megatron/energon/flavors/webdataset/base_webdataset.py
+++ b/src/megatron/energon/flavors/webdataset/base_webdataset.py
@@ -65,7 +65,7 @@ class BaseWebdatasetFactory(
         split_part: str,
         training: bool,
         worker_config: WorkerConfig,
-        shuffle_over_epochs: int = 1,
+        shuffle_over_epochs: Optional[int] = 1,
         parallel_shard_iters: Optional[int] = None,
         max_samples_per_sequence: Optional[int] = None,
         info_config: str = ".info.yaml",

--- a/src/megatron/energon/flavors/webdataset/joined_webdataset.py
+++ b/src/megatron/energon/flavors/webdataset/joined_webdataset.py
@@ -44,7 +44,7 @@ class JoinedWebdatasetFactory(
 
     training: bool
     worker_config: WorkerConfig
-    shuffle_over_epochs: int = 1
+    shuffle_over_epochs: Optional[int] = 1
     parallel_shard_iters: Optional[int]
     max_samples_per_sequence: Optional[int]
     part_filter: Optional[Callable[[str], bool]]
@@ -64,7 +64,7 @@ class JoinedWebdatasetFactory(
         *,
         training: bool,
         worker_config: WorkerConfig,
-        shuffle_over_epochs: int = 1,
+        shuffle_over_epochs: Optional[int] = 1,
         parallel_shard_iters: Optional[int] = None,
         max_samples_per_sequence: Optional[int] = None,
         part_filter: Optional[Callable[[str], bool]] = None,

--- a/src/megatron/energon/flavors/webdataset/sample_loader.py
+++ b/src/megatron/energon/flavors/webdataset/sample_loader.py
@@ -283,7 +283,9 @@ class WebdatasetSampleLoaderDataset(SavableDataset[Tuple[Optional[FilteredSample
         if self.shuffle_over_epochs is None:
             # No shuffling
             res_list = list(shards)
-            shards_offset = 0
+
+            if shards_offset is None:
+                shards_offset = 0
         else:
             # Restore state or start new (and save)
             if shards_offset is None:

--- a/src/megatron/energon/metadataset/dataset_loader.py
+++ b/src/megatron/energon/metadataset/dataset_loader.py
@@ -19,7 +19,7 @@ class DatasetLoader(DatasetLoaderInterface):
     split_part: Optional[str] = None
     subflavor: Optional[str] = None
     subflavors: Optional[Dict[str, Any]] = None
-    shuffle_over_epochs_multiplier: int = 1
+    shuffle_over_epochs_multiplier: Optional[int] = 1
     dataset_config: str = "dataset.yaml"
     split_config: str = "split.yaml"
 
@@ -31,7 +31,7 @@ class DatasetLoader(DatasetLoaderInterface):
         worker_config: WorkerConfig,
         subflavor: Optional[str] = None,
         subflavors: Optional[Dict[str, Any]] = None,
-        shuffle_over_epochs: int = 1,
+        shuffle_over_epochs: Optional[int] = 1,
         split_config: Optional[str] = None,
         dataset_config: Optional[str] = None,
         **kwargs,
@@ -83,7 +83,7 @@ class DatasetLoader(DatasetLoaderInterface):
         worker_config: WorkerConfig,
         subflavor: Optional[str] = None,
         subflavors: Optional[Dict[str, Any]] = None,
-        shuffle_over_epochs_multiplier: int = 1,
+        shuffle_over_epochs_multiplier: Optional[int] = 1,
         **kwargs,
     ) -> Tuple[DatasetBlendMode, List[Tuple[BaseCoreDatasetFactory, Union[float, int, None]]]]:
         return DatasetBlendMode.NONE, [

--- a/src/megatron/energon/metadataset/join_dataset_loader.py
+++ b/src/megatron/energon/metadataset/join_dataset_loader.py
@@ -27,7 +27,7 @@ class JoinDatasetLoader(DatasetLoaderInterface):
     split_config: Optional[str] = None
     subflavor: Optional[str] = None
     subflavors: Optional[Dict[str, Any]] = None
-    shuffle_over_epochs_multiplier: int = 1
+    shuffle_over_epochs_multiplier: Optional[int] = 1
 
     def get_dataset(
         self,
@@ -37,7 +37,7 @@ class JoinDatasetLoader(DatasetLoaderInterface):
         worker_config: WorkerConfig,
         subflavor: Optional[str] = None,
         subflavors: Optional[Dict[str, Any]] = None,
-        shuffle_over_epochs: int = 1,
+        shuffle_over_epochs: Optional[int] = 1,
         split_config: Optional[str] = None,
         **kwargs,
     ) -> BaseCoreDatasetFactory:
@@ -119,7 +119,7 @@ class JoinDatasetLoader(DatasetLoaderInterface):
         worker_config: WorkerConfig,
         subflavor: Optional[str] = None,
         subflavors: Optional[Dict[str, Any]] = None,
-        shuffle_over_epochs_multiplier: int = 1,
+        shuffle_over_epochs_multiplier: Optional[int] = 1,
         **kwargs,
     ) -> Tuple[DatasetBlendMode, List[Tuple[BaseCoreDatasetFactory, Union[float, int, None]]]]:
         return DatasetBlendMode.NONE, [

--- a/src/megatron/energon/metadataset/loader_interface.py
+++ b/src/megatron/energon/metadataset/loader_interface.py
@@ -32,7 +32,7 @@ class DatasetLoaderInterface(ABC):
         worker_config: WorkerConfig,
         subflavor: Optional[str] = None,
         subflavors: Optional[Dict[str, Any]] = None,
-        shuffle_over_epochs_multiplier: int = 1,
+        shuffle_over_epochs_multiplier: Optional[int] = 1,
         **kwargs,
     ) -> Tuple[DatasetBlendMode, List[Tuple[BaseCoreDatasetFactory, Union[float, int, None]]]]:
         """

--- a/src/megatron/energon/metadataset/metadataset.py
+++ b/src/megatron/energon/metadataset/metadataset.py
@@ -19,7 +19,7 @@ class DatasetReference:
     split_part: Optional[str] = None
     subflavor: Optional[str] = None
     subflavors: Optional[Dict[str, Any]] = None
-    shuffle_over_epochs_multiplier: int = 1
+    shuffle_over_epochs_multiplier: Optional[int] = 1
     dataset_config: str = "dataset.yaml"
     split_config: str = "split.yaml"
 
@@ -59,7 +59,7 @@ class DatasetReference:
         worker_config: WorkerConfig,
         subflavor: Optional[str] = None,
         subflavors: Optional[Dict[str, Any]] = None,
-        shuffle_over_epochs_multiplier: int = 1,
+        shuffle_over_epochs_multiplier: Optional[int] = 1,
         **kwargs,
     ) -> Tuple[DatasetBlendMode, List[Tuple[BaseCoreDatasetFactory, Union[float, int, None]]]]:
         if self.subflavors is not None:
@@ -96,7 +96,7 @@ class MetadatasetBlender:
         worker_config: WorkerConfig,
         subflavor: Optional[str] = None,
         subflavors: Optional[Dict[str, Any]] = None,
-        shuffle_over_epochs_multiplier: int = 1,
+        shuffle_over_epochs_multiplier: Optional[int] = 1,
         **kwargs,
     ) -> Tuple[DatasetBlendMode, List[Tuple[BaseCoreDatasetFactory, Union[float, int, None]]]]:
         sum_weight = sum(dataset.weight for dataset in self.datasets)
@@ -150,7 +150,7 @@ class Metadataset(DatasetLoaderInterface):
         worker_config: WorkerConfig,
         subflavor: Optional[str] = None,
         subflavors: Optional[Dict[str, Any]] = None,
-        shuffle_over_epochs_multiplier: int = 1,
+        shuffle_over_epochs_multiplier: Optional[int] = 1,
         **kwargs,
     ) -> Tuple[DatasetBlendMode, List[Tuple[BaseCoreDatasetFactory, Union[float, int, None]]]]:
         return self._splits[split_part].get_datasets(

--- a/src/megatron/energon/metadataset/metadataset_v2.py
+++ b/src/megatron/energon/metadataset/metadataset_v2.py
@@ -73,7 +73,10 @@ class DatasetReference(DatasetLoaderInterface):
             subflavors=subflavors,
             shuffle_over_epochs_multiplier=(
                 shuffle_over_epochs_multiplier * self.shuffle_over_epochs_multiplier
-                if (shuffle_over_epochs_multiplier is not None and self.shuffle_over_epochs_multiplier is not None)
+                if (
+                    shuffle_over_epochs_multiplier is not None
+                    and self.shuffle_over_epochs_multiplier is not None
+                )
                 else None
             ),
             **kwargs,

--- a/src/megatron/energon/metadataset/metadataset_v2.py
+++ b/src/megatron/energon/metadataset/metadataset_v2.py
@@ -65,20 +65,26 @@ class DatasetReference(DatasetLoaderInterface):
         if self.subflavors is not None:
             subflavors = {**self.subflavors, **(subflavors or {})}
         assert self._dataset is not None
+
+        if shuffle_over_epochs_multiplier is None or self.shuffle_over_epochs_multiplier is None:
+            # If no shuffling is requested, this has override priority.
+            new_shuffle_over_epochs_multiplier = None
+        elif shuffle_over_epochs_multiplier == -1 or self.shuffle_over_epochs_multiplier == -1:
+            # Next priority is sampling without replacement.
+            new_shuffle_over_epochs_multiplier = -1
+        else:
+            # Otherwise, multiply the shuffle over epochs multiplier.
+            new_shuffle_over_epochs_multiplier = (
+                shuffle_over_epochs_multiplier * self.shuffle_over_epochs_multiplier
+            )
+
         return self._dataset.get_datasets(
             training=training,
             split_part=self.split_part or split_part,
             worker_config=worker_config,
             subflavor=subflavor or self.subflavor,
             subflavors=subflavors,
-            shuffle_over_epochs_multiplier=(
-                shuffle_over_epochs_multiplier * self.shuffle_over_epochs_multiplier
-                if (
-                    shuffle_over_epochs_multiplier is not None
-                    and self.shuffle_over_epochs_multiplier is not None
-                )
-                else None
-            ),
+            shuffle_over_epochs_multiplier=new_shuffle_over_epochs_multiplier,
             **kwargs,
         )
 

--- a/src/megatron/energon/metadataset/metadataset_v2.py
+++ b/src/megatron/energon/metadataset/metadataset_v2.py
@@ -231,7 +231,7 @@ class MetadatasetBlend(DatasetLoaderInterface):
 
 @dataclass
 class BlendRepetitionsMixin:
-    repetitions: int = 1
+    repetitions: Union[int, float] = 1
 
 
 @dataclass

--- a/src/megatron/energon/metadataset/metadataset_v2.py
+++ b/src/megatron/energon/metadataset/metadataset_v2.py
@@ -21,7 +21,7 @@ class DatasetReference(DatasetLoaderInterface):
     split_part: Optional[str] = None
     subflavor: Optional[str] = None
     subflavors: Optional[Dict[str, Any]] = None
-    shuffle_over_epochs_multiplier: int = 1
+    shuffle_over_epochs_multiplier: Optional[int] = 1
     dataset_config: str = "dataset.yaml"
     split_config: str = "split.yaml"
 
@@ -59,7 +59,7 @@ class DatasetReference(DatasetLoaderInterface):
         worker_config: WorkerConfig,
         subflavor: Optional[str] = None,
         subflavors: Optional[Dict[str, Any]] = None,
-        shuffle_over_epochs_multiplier: int = 1,
+        shuffle_over_epochs_multiplier: Optional[int] = 1,
         **kwargs,
     ) -> Tuple[DatasetBlendMode, List[Tuple[BaseCoreDatasetFactory, Union[float, int, None]]]]:
         if self.subflavors is not None:
@@ -71,8 +71,11 @@ class DatasetReference(DatasetLoaderInterface):
             worker_config=worker_config,
             subflavor=subflavor or self.subflavor,
             subflavors=subflavors,
-            shuffle_over_epochs_multiplier=shuffle_over_epochs_multiplier
-            * self.shuffle_over_epochs_multiplier,
+            shuffle_over_epochs_multiplier=(
+                shuffle_over_epochs_multiplier * self.shuffle_over_epochs_multiplier
+                if (shuffle_over_epochs_multiplier is not None and self.shuffle_over_epochs_multiplier is not None)
+                else None
+            ),
             **kwargs,
         )
 
@@ -114,7 +117,7 @@ class MetadatasetJoin(DatasetLoaderInterface):
     split_part: Optional[str] = None
     subflavor: Optional[str] = None
     subflavors: Optional[Dict[str, Any]] = None
-    shuffle_over_epochs_multiplier: int = 1
+    shuffle_over_epochs_multiplier: Optional[int] = 1
     dataset_config: str = "dataset.yaml"
     split_config: str = "split.yaml"
 
@@ -151,7 +154,7 @@ class MetadatasetJoin(DatasetLoaderInterface):
         worker_config: WorkerConfig,
         subflavor: Optional[str] = None,
         subflavors: Optional[Dict[str, Any]] = None,
-        shuffle_over_epochs_multiplier: int = 1,
+        shuffle_over_epochs_multiplier: Optional[int] = 1,
         **kwargs,
     ) -> Tuple[DatasetBlendMode, List[Tuple[BaseCoreDatasetFactory, Union[float, int, None]]]]:
         assert self._dataset is not None, "Not prepared."
@@ -200,7 +203,7 @@ class MetadatasetBlend(DatasetLoaderInterface):
         worker_config: WorkerConfig,
         subflavor: Optional[str] = None,
         subflavors: Optional[Dict[str, Any]] = None,
-        shuffle_over_epochs_multiplier: int = 1,
+        shuffle_over_epochs_multiplier: Optional[int] = 1,
         **kwargs,
     ) -> Tuple[DatasetBlendMode, List[Tuple[BaseCoreDatasetFactory, Union[float, int, None]]]]:
         sum_weight = sum(dataset.weight for dataset in self.blend)
@@ -266,7 +269,7 @@ class MetadatasetBlendEpochized(DatasetLoaderInterface):
         worker_config: WorkerConfig,
         subflavor: Optional[str] = None,
         subflavors: Optional[Dict[str, Any]] = None,
-        shuffle_over_epochs_multiplier: int = 1,
+        shuffle_over_epochs_multiplier: Optional[int] = 1,
         **kwargs,
     ) -> Tuple[DatasetBlendMode, List[Tuple[BaseCoreDatasetFactory, Union[float, int, None]]]]:
         datasets = []
@@ -316,7 +319,7 @@ class MetadatasetV2(DatasetLoaderInterface):
         worker_config: WorkerConfig,
         subflavor: Optional[str] = None,
         subflavors: Optional[Dict[str, Any]] = None,
-        shuffle_over_epochs_multiplier: int = 1,
+        shuffle_over_epochs_multiplier: Optional[int] = 1,
         **kwargs,
     ) -> Tuple[DatasetBlendMode, List[Tuple[BaseCoreDatasetFactory, Union[float, int, None]]]]:
         return self.splits[split_part].get_datasets(

--- a/src/megatron/energon/task_encoder/base.py
+++ b/src/megatron/energon/task_encoder/base.py
@@ -529,7 +529,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
                 DatasetBlendMode.NONE,
                 DatasetBlendMode.SAMPLE_REPETITIONS,
             ) and all(
-                isinstance(repetitions, int) for _dataset, repetitions in datasets
+                isinstance(repetitions, (int, float)) for _dataset, repetitions in datasets
             ), "If repeat is False, the datasets must be repeated with integer weights."
             inner_datasets = [
                 (
@@ -538,7 +538,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
                         if repetition is None or repetition == 1
                         else RepeatDataset(
                             dataset.build(worker_rotation_offset=worker_rotation_offset),
-                            repeats=int(repetition),
+                            repeats=repetition,
                             worker_config=worker_config,
                         )
                     ),

--- a/src/megatron/energon/task_encoder/base.py
+++ b/src/megatron/energon/task_encoder/base.py
@@ -542,7 +542,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
                             worker_config=worker_config,
                         )
                     ),
-                    len(dataset) * (1 if repetition is None else int(repetition)),
+                    len(dataset) * (1 if repetition is None else repetition),
                 )
                 for (dataset, repetition), worker_rotation_offset in zip(
                     datasets, worker_rotation_offsets

--- a/src/megatron/energon/task_encoder/loader.py
+++ b/src/megatron/energon/task_encoder/loader.py
@@ -45,7 +45,7 @@ def get_train_dataset(
     shuffle_buffer_size: Optional[int],
     max_samples_per_sequence: Optional[int],
     virtual_epoch_length: int = 0,
-    shuffle_over_epochs_multiplier: int = 1,
+    shuffle_over_epochs_multiplier: Optional[int] = 1,
     task_encoder: TaskEncoder[Any, Any, Any, T] = DefaultTaskEncoder(),
     repeat: bool = True,
     **kwargs,

--- a/src/megatron/energon/wrappers/blend_dataset.py
+++ b/src/megatron/energon/wrappers/blend_dataset.py
@@ -133,7 +133,7 @@ class BlendDataset(BaseWrapperDataset[T_sample], Generic[T_sample]):
                 d.merge_states([None if s is None else s.datasets[ds_idx] for s in states])
                 for ds_idx, (d, _) in enumerate(self.dataset_weights)
             ],
-            exhausted=deepcopy([s.exhausted for s in states]),
+            exhausted=[s.exhausted for s in states],
             rng=self._worker_rng.merge_states([None if s is None else s.rng for s in states]),
         )
 

--- a/src/megatron/energon/wrappers/blend_dataset.py
+++ b/src/megatron/energon/wrappers/blend_dataset.py
@@ -120,9 +120,8 @@ class BlendDataset(BaseWrapperDataset[T_sample], Generic[T_sample]):
     def save_state(self) -> BlendDatasetState:
         return BlendDatasetState(
             datasets=[d.save_state() for d, _weight in self.dataset_weights],
-            exhausted=list(
-                self.exhausted[self.worker_config.rank_worker_id()]
-            ),  # Need list() to create a copy
+            # Need list() to create a copy
+            exhausted=list(self.exhausted[self.worker_config.rank_worker_id()]),
             rng=self._worker_rng.save_state(),
         )
 
@@ -155,9 +154,8 @@ class BlendDataset(BaseWrapperDataset[T_sample], Generic[T_sample]):
             for (dataset, _weight), dstate in zip(self.dataset_weights, state.datasets):
                 dataset.restore_state(dstate)
             self._worker_rng.restore_state(state.rng)
-            self.exhausted = [
-                list(sub) for sub in state.exhausted
-            ]  # Need [list() for ...] to create a deep copy
+            # Need [list() for ...] to create a deep copy
+            self.exhausted = [list(sub) for sub in state.exhausted]
 
     def can_restore_sample(self) -> bool:
         return all(dataset.can_restore_sample() for dataset, _weight in self.dataset_weights)

--- a/src/megatron/energon/wrappers/blend_dataset.py
+++ b/src/megatron/energon/wrappers/blend_dataset.py
@@ -23,6 +23,8 @@ T_sample = TypeVar("T_sample")
 class BlendDatasetState(State):
     #: States of the sub datasets
     datasets: List[State]
+    #: Whether the subdatasets are done
+    exhausted: List[bool]
     #: State of the worker rng
     rng: WorkerRngState
 
@@ -31,6 +33,8 @@ class BlendDatasetState(State):
 class BlendDatasetMergedState(MergedState):
     #: States of the sub datasets
     datasets: List[MergedState]
+    #: Whether the dataset is done
+    exhausted: List[List[bool]]
     #: State of the worker rng
     rng: WorkerRngMergedState
 
@@ -42,7 +46,7 @@ class BlendDataset(BaseWrapperDataset[T_sample], Generic[T_sample]):
     """
 
     dataset_weights: Tuple[Tuple[SavableDataset[T_sample], float], ...]
-
+    exhausted: List[List[bool]]
     _worker_rng: WorkerRng
 
     def __init__(
@@ -63,6 +67,9 @@ class BlendDataset(BaseWrapperDataset[T_sample], Generic[T_sample]):
 
         self.dataset_weights = dataset_weights
         self._worker_rng = WorkerRng(self.worker_config)
+        self.exhausted = [
+            [False] * len(dataset_weights) for _ in range(max(self.worker_config.num_workers, 1))
+        ]
 
     def __len__(self) -> int:
         # Give the number of samples in inner datasets, disregarding the weight
@@ -82,6 +89,11 @@ class BlendDataset(BaseWrapperDataset[T_sample], Generic[T_sample]):
         probs = weights / weights.sum()
         assert torch.all(probs > 0), "Negative weights are not allowed"
 
+        for idx, exhausted in enumerate(self.exhausted[self.worker_config.rank_worker_id()]):
+            if exhausted:
+                probs[idx] = 0
+                dataset_iters[idx] = None
+
         while True:
             ds_idx = self._worker_rng.choice_idx(probs=probs)
             if dataset_iters[ds_idx] is None:
@@ -93,10 +105,13 @@ class BlendDataset(BaseWrapperDataset[T_sample], Generic[T_sample]):
             except StopIteration:
                 dataset_iters[ds_idx] = None
                 probs[ds_idx] = 0
+                self.exhausted[self.worker_config.rank_worker_id()][ds_idx] = True
                 if all(dataset_iter is None for dataset_iter in dataset_iters):
                     break
             else:
                 yield add_sample_restore_key(sample, ds_idx, src=self)
+
+        self.exhausted[self.worker_config.rank_worker_id()] = [False] * len(self.dataset_weights)
 
     def worker_has_samples(self) -> bool:
         return any(dataset.worker_has_samples() for dataset, _weight in self.dataset_weights)
@@ -104,6 +119,7 @@ class BlendDataset(BaseWrapperDataset[T_sample], Generic[T_sample]):
     def save_state(self) -> BlendDatasetState:
         return BlendDatasetState(
             datasets=[d.save_state() for d, _weight in self.dataset_weights],
+            exhausted=self.exhausted[self.worker_config.rank_worker_id()],
             rng=self._worker_rng.save_state(),
         )
 
@@ -115,6 +131,7 @@ class BlendDataset(BaseWrapperDataset[T_sample], Generic[T_sample]):
                 d.merge_states([None if s is None else s.datasets[ds_idx] for s in states])
                 for ds_idx, (d, _) in enumerate(self.dataset_weights)
             ],
+            exhausted=[s.exhausted for s in states],
             rng=self._worker_rng.merge_states([None if s is None else s.rng for s in states]),
         )
 
@@ -123,6 +140,10 @@ class BlendDataset(BaseWrapperDataset[T_sample], Generic[T_sample]):
             for dataset, _weight in self.dataset_weights:
                 dataset.restore_state(None)
             self._worker_rng.restore_state(None)
+            self.exhausted = [
+                [False] * len(self.dataset_weights)
+                for _ in range(max(self.worker_config.num_workers, 1))
+            ]
         else:
             assert isinstance(state, BlendDatasetMergedState)
             assert len(state.datasets) == len(
@@ -131,6 +152,7 @@ class BlendDataset(BaseWrapperDataset[T_sample], Generic[T_sample]):
             for (dataset, _weight), dstate in zip(self.dataset_weights, state.datasets):
                 dataset.restore_state(dstate)
             self._worker_rng.restore_state(state.rng)
+            self.exhausted = state.exhausted
 
     def can_restore_sample(self) -> bool:
         return all(dataset.can_restore_sample() for dataset, _weight in self.dataset_weights)

--- a/src/megatron/energon/wrappers/repeat_dataset.py
+++ b/src/megatron/energon/wrappers/repeat_dataset.py
@@ -67,8 +67,10 @@ class RepeatDataset(BaseSingleWrapperDataset[T_sample, T_sample], Generic[T_samp
         assert (
             self.repeats is not None or self.dataset.worker_has_samples()
         ), "Cannot repeat empty dataset indefinitely"
+
+        ds_len = len(self.dataset)
+
         while self.repeats is None or self._repetition[worker_idx] < self.repeats:
-            ds_len = len(self.dataset)
             if self.repeats is not None and self._repetition[worker_idx] == math.floor(
                 self.repeats
             ):

--- a/src/megatron/energon/wrappers/repeat_dataset.py
+++ b/src/megatron/energon/wrappers/repeat_dataset.py
@@ -78,10 +78,9 @@ class RepeatDataset(BaseSingleWrapperDataset[T_sample, T_sample], Generic[T_samp
             else:
                 stop_after = None
 
-            self._index[worker_idx] = 0
             for sample in self.dataset:
-                yield sample
                 self._index[worker_idx] += 1
+                yield sample
                 if stop_after is not None and self._index[worker_idx] >= stop_after:
                     break
 
@@ -96,6 +95,8 @@ class RepeatDataset(BaseSingleWrapperDataset[T_sample, T_sample], Generic[T_samp
                     }
                 )
             self._repetition[worker_idx] += 1
+            self._index[worker_idx] = 0
+
         if self.restart:
             self._repetition[worker_idx] = 0
         else:

--- a/src/megatron/energon/wrappers/repeat_dataset.py
+++ b/src/megatron/energon/wrappers/repeat_dataset.py
@@ -78,6 +78,7 @@ class RepeatDataset(BaseSingleWrapperDataset[T_sample, T_sample], Generic[T_samp
             else:
                 stop_after = None
 
+            self._index[worker_idx] = 0
             for sample in self.dataset:
                 yield sample
                 self._index[worker_idx] += 1

--- a/src/megatron/energon/wrappers/repeat_dataset.py
+++ b/src/megatron/energon/wrappers/repeat_dataset.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import math
 from dataclasses import dataclass
-from typing import Any, Dict, Generic, Iterator, List, Optional, TypeVar
+from typing import Any, Dict, Generic, Iterator, List, Optional, TypeVar, Union
 
 from megatron.energon.flavors.base_dataset import SavableDataset
 from megatron.energon.worker import WorkerConfig
@@ -18,24 +19,26 @@ T_sample = TypeVar("T_sample")
 @dataclass
 class RepeatState(BaseSingleWrapperState):
     repetition: int
+    index: int
 
 
 @dataclass
 class RepeatMergedState(BaseSingleWrapperMergedState):
     repetition: List[int]
+    index: List[int]
 
 
 class RepeatDataset(BaseSingleWrapperDataset[T_sample, T_sample], Generic[T_sample]):
     """This dataset repeats the inner dataset indefinitely or a specific number of repeats."""
 
-    repeats: Optional[int]
+    repeats: Optional[Union[int, float]]
     _repetition: List[int]
 
     def __init__(
         self,
         dataset: SavableDataset[T_sample],
         *,
-        repeats: Optional[int] = None,
+        repeats: Optional[Union[int, float]] = None,
         restart: bool = True,
         worker_config: WorkerConfig,
     ):
@@ -52,6 +55,7 @@ class RepeatDataset(BaseSingleWrapperDataset[T_sample, T_sample], Generic[T_samp
         self.repeats = repeats
         self.restart = restart
         self._repetition = [0] * max(self.worker_config.num_workers, 1)
+        self._index = [0] * max(self.worker_config.num_workers, 1)
 
     def __len__(self):
         if self.repeats is None:
@@ -64,8 +68,22 @@ class RepeatDataset(BaseSingleWrapperDataset[T_sample, T_sample], Generic[T_samp
             self.repeats is not None or self.dataset.worker_has_samples()
         ), "Cannot repeat empty dataset indefinitely"
         while self.repeats is None or self._repetition[worker_idx] < self.repeats:
+            ds_len = len(self.dataset)
+            if self.repeats is not None and self._repetition[worker_idx] == math.floor(
+                self.repeats
+            ):
+                # Last iteration, adjust the number of samples
+                fraction = self.repeats - math.floor(self.repeats)
+                stop_after = math.floor(ds_len * fraction)
+            else:
+                stop_after = None
+
             for sample in self.dataset:
                 yield sample
+                self._index[worker_idx] += 1
+                if stop_after is not None and self._index[worker_idx] >= stop_after:
+                    break
+
             if self.worker_config.should_log(level=2):
                 self.worker_config.worker_log(
                     {
@@ -81,12 +99,13 @@ class RepeatDataset(BaseSingleWrapperDataset[T_sample, T_sample], Generic[T_samp
             self._repetition[worker_idx] = 0
         else:
             # No more repeats
-            self._repetition[worker_idx] = self.repeats
+            self._repetition[worker_idx] = math.ceil(self.repeats)
 
     def save_state(self) -> RepeatState:
         return RepeatState.extend(
             super().save_state(),
             repetition=self._repetition[self.worker_config.rank_worker_id()],
+            index=self._index[self.worker_config.rank_worker_id()],
         )
 
     def merge_states(self, states: List[RepeatState]) -> RepeatMergedState:
@@ -94,15 +113,18 @@ class RepeatDataset(BaseSingleWrapperDataset[T_sample, T_sample], Generic[T_samp
         return RepeatMergedState.extend(
             super().merge_states(states),
             repetition=[0 if state is None else state.repetition for state in states],
+            index=[0 if state is None else state.index for state in states],
         )
 
     def restore_state(self, state: Optional[RepeatMergedState]) -> None:
         super().restore_state(state)
         if state is None:
             self._repetition = [0] * max(self.worker_config.num_workers, 1)
+            self._index = [0] * max(self.worker_config.num_workers, 1)
         else:
             assert isinstance(state, RepeatMergedState)
             self._repetition = state.repetition
+            self._index = state.index
 
     def config(self) -> Dict[str, Any]:
         return {

--- a/src/megatron/energon/wrappers/repeat_dataset.py
+++ b/src/megatron/energon/wrappers/repeat_dataset.py
@@ -77,6 +77,9 @@ class RepeatDataset(BaseSingleWrapperDataset[T_sample, T_sample], Generic[T_samp
                 # Last iteration, adjust the number of samples
                 fraction = self.repeats - math.floor(self.repeats)
                 stop_after = math.floor(ds_len * fraction)
+                if self._index[worker_idx] >= stop_after:
+                    # We restored an index and it is already past the stop_after
+                    break
             else:
                 stop_after = None
 

--- a/tests/test_metadataset_v2.py
+++ b/tests/test_metadataset_v2.py
@@ -186,8 +186,9 @@ class TestDataset(unittest.TestCase):
             f.write(
                 "\n".join(
                     [
-                        "__module__: megatron.energon",
-                        "__class__: TextWebdataset",
+                        "sample_type:",
+                        "  __module__: megatron.energon",
+                        "  __class__: TextSample",
                         "field_map:",
                         "  text: txt",
                         "subflavors:",
@@ -615,6 +616,133 @@ class TestDataset(unittest.TestCase):
         assert all(ds2_key_cnt_rst[key] == 3 for key in ds2_keys_rst)
         assert all(txt_cnt_rst[key] in (2, 3) for key in txt_order_rst)
 
+    def test_metadataset_fixed_fractional_epochs(self):
+        torch.manual_seed(42)
+        worker_config = WorkerConfig(
+            rank=0,
+            world_size=1,
+            num_workers=0,
+            seed_offset=42,
+        )
+
+        # Create a joined dataset configuration
+        fixed_epochs_mds_path = self.dataset_path / "metadataset_fixed_epochs.yaml"
+        with open(fixed_epochs_mds_path, "w") as f:
+            f.write(
+                "\n".join(
+                    [
+                        "__module__: megatron.energon",
+                        "__class__: MetadatasetV2",
+                        "splits:",
+                        "  train:",
+                        "    blend_epochized:",
+                        "      - repetitions: 0.7",
+                        "        path: ds1",
+                        "        subflavors:",
+                        "          source: ds1",
+                        "          number: 43",
+                        "      - repetitions: 1.5",
+                        "        path: ds2",
+                        "        subflavors:",
+                        "          source: ds2",
+                        "          number: 42",
+                    ]
+                )
+            )
+
+        # Train mode dataset
+        train_dataset = get_train_dataset(
+            fixed_epochs_mds_path,
+            worker_config=worker_config,
+            batch_size=1,
+            shuffle_buffer_size=None,
+            shuffle_over_epochs_multiplier=None,
+            parallel_shard_iters=1,
+            max_samples_per_sequence=None,
+            repeat=False,
+        )
+
+        train_loader = get_savable_loader(
+            train_dataset,
+            checkpoint_every_sec=0,
+            checkpoint_every_min_n_samples=1,
+            n_checkpoints=5,
+        )
+
+        data = list(enumerate(train_loader))
+
+        # Check the overall number of samples
+        # Should be 0.7*len(ds1) + 1.5*len(ds2) = 38 + 55 + 27 (floor rounding)
+        assert len(data) == 38 + 55 + 27, len(data)
+
+        sample_counts = Counter([int(s[1].text[0]) for s in data])
+
+        # The first 70% of samples from ds1 (0 to incl. 37) should be repeated only once
+        assert all(sample_counts[sample] == 1 for sample in range(38))
+
+        # Since ds2 is repeated 1.5 times, the first 50% of samples from ds2 (100 to incl. 126) should be repeated twice
+        assert all(sample_counts[sample] == 2 for sample in range(100, 127))
+
+        # The remaining samples from ds2 (127 to incl. 154) should be repeated only once
+        assert all(sample_counts[sample] == 1 for sample in range(127, 155))
+
+        # Now let's check if the state is stored and restored correctly
+
+        train_loader = get_savable_loader(
+            get_train_dataset(
+                fixed_epochs_mds_path,
+                worker_config=worker_config,
+                batch_size=1,
+                shuffle_buffer_size=None,
+                shuffle_over_epochs_multiplier=None,
+                parallel_shard_iters=1,
+                max_samples_per_sequence=None,
+                repeat=False,
+            ),
+            checkpoint_every_sec=0,
+            checkpoint_every_min_n_samples=1,
+            n_checkpoints=5,
+        )
+
+        data1 = list(zip(range(95), train_loader))
+        state1 = train_loader.save_state_rank()
+
+        train_loader = get_savable_loader(
+            get_train_dataset(
+                fixed_epochs_mds_path,
+                worker_config=worker_config,
+                batch_size=1,
+                shuffle_buffer_size=None,
+                shuffle_over_epochs_multiplier=None,
+                parallel_shard_iters=1,
+                max_samples_per_sequence=None,
+                repeat=False,
+            ),
+            checkpoint_every_sec=0,
+            checkpoint_every_min_n_samples=1,
+            n_checkpoints=5,
+        )
+        train_loader.restore_state_rank(state1)
+        data2_restore = list(enumerate(train_loader))
+
+        total_samples_save_restore = len(data1) + len(data2_restore)
+
+        assert total_samples_save_restore == len(
+            data
+        ), "Total number of samples do not match when using save/restore"
+
+        sample_counts_save_restore = Counter(
+            [int(s[1].text[0]) for d in [data1, data2_restore] for s in d]
+        )
+
+        assert (
+            sample_counts_save_restore == sample_counts
+        ), "Sample counts do not match when using save/restore"
+
 
 if __name__ == "__main__":
-    unittest.main()
+    # unittest.main()
+    test = TestDataset()
+    test.setUp()
+    test.test_metadataset_fixed_fractional_epochs()
+    test.tearDown()


### PR DESCRIPTION
Allow not just integer repeat count but also float. That means a dataset with `0.5` repetitions would end after half the dataset. Also `2.5` would be possible for two and a half epochs.