### PR TITLE
GC Dataset: make gc_collect_every_n_steps configurable and add a new default

### DIFF
--- a/src/megatron/energon/loader.py
+++ b/src/megatron/energon/loader.py
@@ -7,6 +7,7 @@ from megatron.energon.errors import warn_deprecated
 from megatron.energon.flavors.base_dataset import SavableDataset
 from megatron.energon.savable_loader import BasicDataLoader, SavableDataLoader
 from megatron.energon.worker import WorkerConfig
+from megatron.energon.wrappers.gc_dataset import GC_DEFAULT_EVERY_N_ITER
 
 T = TypeVar("T")
 
@@ -18,6 +19,7 @@ def get_savable_loader(
     checkpoint_every_sec: float = 60,
     checkpoint_every_min_n_samples: Optional[int] = None,
     n_checkpoints: int = 2,
+    gc_collect_every_n_steps: int = GC_DEFAULT_EVERY_N_ITER,
 ) -> SavableDataLoader[T]:
     """
 
@@ -54,6 +56,7 @@ def get_savable_loader(
         checkpoint_every_sec=checkpoint_every_sec,
         checkpoint_every_min_n_samples=checkpoint_every_min_n_samples,
         n_checkpoints=n_checkpoints,
+        gc_collect_every_n_steps=gc_collect_every_n_steps,
     )
 
 

--- a/src/megatron/energon/savable_loader.py
+++ b/src/megatron/energon/savable_loader.py
@@ -42,7 +42,7 @@ from megatron.energon.flavors.base_dataset import (
 from megatron.energon.rng import SystemRng
 from megatron.energon.worker import WorkerConfig
 from megatron.energon.wrappers.base import BaseSingleWrapperMergedState, BaseSingleWrapperState
-from megatron.energon.wrappers.gc_dataset import GcDataset, gc_init_worker
+from megatron.energon.wrappers.gc_dataset import GC_DEFAULT_EVERY_N_ITER, GcDataset, gc_init_worker
 from megatron.energon.wrappers.log_sample_dataset import default_get_keys
 
 T = TypeVar("T")
@@ -704,7 +704,7 @@ class SavableDataLoader(DataLoader[T], Generic[T]):
         checkpoint_every_sec: float = 60,
         checkpoint_every_min_n_samples: Optional[int] = None,
         n_checkpoints: int = 2,
-        gc_collect_every_n_steps: int = 1,
+        gc_collect_every_n_steps: int = GC_DEFAULT_EVERY_N_ITER,
         gc_freeze_at_start: bool = True,
     ):
         """
@@ -1108,7 +1108,7 @@ class BasicDataLoader(DataLoader[T], Generic[T]):
     def __init__(
         self,
         dataset: SavableDataset[T],
-        gc_collect_every_n_steps: int = 1,
+        gc_collect_every_n_steps: int = GC_DEFAULT_EVERY_N_ITER,
         gc_freeze_at_start: bool = True,
     ):
         """

--- a/src/megatron/energon/wrappers/gc_dataset.py
+++ b/src/megatron/energon/wrappers/gc_dataset.py
@@ -20,6 +20,9 @@ _frozen_cuda_tensors = set()
 _frozen_cuda_tensors_initialized = False
 
 
+GC_DEFAULT_EVERY_N_ITER = 10
+
+
 class GcFreezeError(RuntimeError):
     pass
 
@@ -74,7 +77,7 @@ class GcDataset(BaseSingleWrapperDataset[T_sample, T_sample], Generic[T_sample])
         dataset: SavableDataset[T_sample],
         *,
         worker_config: WorkerConfig,
-        every_n_iter: int = 1,
+        every_n_iter: int = GC_DEFAULT_EVERY_N_ITER,
         freeze: bool = True,
     ):
         """Construct a GcDataset, which applies garbage collection every `every_n_iter` iterations.


### PR DESCRIPTION
GC collect is slowing down the iteration. In the long run we'd like to optimize this e.g. by querying RAM usage, but for now let's make it configurable and set the default to every 10 iters instead of every iter.