### PR TITLE
Add prefetch_factor arg for loader

### DIFF
--- a/src/megatron/energon/loader.py
+++ b/src/megatron/energon/loader.py
@@ -20,6 +20,7 @@ def get_savable_loader(
     checkpoint_every_min_n_samples: Optional[int] = None,
     n_checkpoints: int = 2,
     gc_collect_every_n_steps: int = GC_DEFAULT_EVERY_N_ITER,
+    prefetch_factor: int = 2,
 ) -> SavableDataLoader[T]:
     """
 
@@ -57,6 +58,7 @@ def get_savable_loader(
         checkpoint_every_min_n_samples=checkpoint_every_min_n_samples,
         n_checkpoints=n_checkpoints,
         gc_collect_every_n_steps=gc_collect_every_n_steps,
+        prefetch_factor=prefetch_factor,
     )
 
 
@@ -64,6 +66,7 @@ def get_loader(
     dataset: SavableDataset[T],
     *,
     worker_config: Optional[WorkerConfig] = None,
+    prefetch_factor: int = 2,
 ) -> BasicDataLoader[T]:
     """
     Get a dataloader for the given dataset.
@@ -86,4 +89,4 @@ def get_loader(
                 "Passing a worker_config to get_loader() is deprecated and will have no effect."
             )
 
-    return BasicDataLoader(dataset)
+    return BasicDataLoader(dataset, prefetch_factor=prefetch_factor)

--- a/src/megatron/energon/loader.py
+++ b/src/megatron/energon/loader.py
@@ -18,7 +18,7 @@ def get_savable_loader(
     worker_config: Optional[WorkerConfig] = None,
     checkpoint_every_sec: float = 60,
     checkpoint_every_min_n_samples: Optional[int] = None,
-    n_checkpoints: int = 2,
+    n_checkpoints: Optional[int] = None,
     gc_collect_every_n_steps: int = GC_DEFAULT_EVERY_N_ITER,
     prefetch_factor: int = 2,
 ) -> SavableDataLoader[T]:
@@ -36,6 +36,7 @@ def get_savable_loader(
         checkpoint_every_min_n_samples: Overwrites the minimum number of samples between
             checkpoints. Defaults to `number of workers * 2`. Only applies if using workers.
         n_checkpoints: The number of internal checkpoints to keep. Only applies if using workers.
+            If None, computes a suitable value.
 
     Returns:
         The instantiated :class:`megatron.energon.SavableDataLoader`, yielding batches from the dataset,

--- a/src/megatron/energon/savable_loader.py
+++ b/src/megatron/energon/savable_loader.py
@@ -664,7 +664,7 @@ class SavableDataLoader(DataLoader[T], Generic[T]):
                 checkpoint_every_min_n_samples = self.worker_config.num_workers * 2
 
             if n_checkpoints is None:
-                n_checkpoints = prefetch_factor * num_procs + 2
+                n_checkpoints = prefetch_factor * num_procs + 1
 
             dataset = SavableDatasetWrapper(
                 dataset,

--- a/src/megatron/energon/savable_loader.py
+++ b/src/megatron/energon/savable_loader.py
@@ -659,12 +659,12 @@ class SavableDataLoader(DataLoader[T], Generic[T]):
 
         num_procs = max(self.worker_config.num_workers, 1)
 
+        if n_checkpoints is None:
+            n_checkpoints = prefetch_factor * num_procs + 1
+
         if self.worker_config.num_workers > 0:
             if checkpoint_every_min_n_samples is None:
                 checkpoint_every_min_n_samples = self.worker_config.num_workers * 2
-
-            if n_checkpoints is None:
-                n_checkpoints = prefetch_factor * num_procs + 1
 
             dataset = SavableDatasetWrapper(
                 dataset,

--- a/tests/test_crudedataset.py
+++ b/tests/test_crudedataset.py
@@ -255,7 +255,6 @@ class TestDataset(unittest.TestCase):
             ),
             checkpoint_every_sec=0,
             checkpoint_every_min_n_samples=1,
-            n_checkpoints=4,
         )
         samples = [s.__keys__ for idx, s in zip(range(100), loader)]
 
@@ -278,7 +277,6 @@ class TestDataset(unittest.TestCase):
             ),
             checkpoint_every_sec=0,
             checkpoint_every_min_n_samples=1,
-            n_checkpoints=4,
         )
 
         loader.restore_state_rank(state)
@@ -307,7 +305,6 @@ class TestDataset(unittest.TestCase):
             ),
             checkpoint_every_sec=0,
             checkpoint_every_min_n_samples=1,
-            n_checkpoints=4,
         )
         samples = [s.__keys__ for idx, s in zip(range(100), loader)]
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1504,7 +1504,6 @@ class TestDataset(unittest.TestCase):
             ),
             checkpoint_every_min_n_samples=1,
             checkpoint_every_sec=0,
-            n_checkpoints=4,
         )
         batches = list(zip(range(40), loader))
         print([batch.__key__ for idx, batch in batches])
@@ -1525,7 +1524,6 @@ class TestDataset(unittest.TestCase):
             ),
             checkpoint_every_min_n_samples=1,
             checkpoint_every_sec=0,
-            n_checkpoints=4,
         )
 
         batches = list(zip(range(40), loader_r0))
@@ -1551,7 +1549,6 @@ class TestDataset(unittest.TestCase):
             ),
             checkpoint_every_min_n_samples=1,
             checkpoint_every_sec=0,
-            n_checkpoints=4,
         )
         loader_r0.restore_state_rank(state)
 

--- a/tests/test_metadataset.py
+++ b/tests/test_metadataset.py
@@ -900,7 +900,6 @@ class TestDataset(unittest.TestCase):
                 ),
                 checkpoint_every_sec=0.5,
                 checkpoint_every_min_n_samples=1,
-                n_checkpoints=5,
             )
 
         # Train mode dataset

--- a/tests/test_metadataset_fewsamp.py
+++ b/tests/test_metadataset_fewsamp.py
@@ -176,7 +176,6 @@ class TestDataset(unittest.TestCase):
             train_dataset,
             checkpoint_every_sec=0,
             checkpoint_every_min_n_samples=1,
-            n_checkpoints=5,
         )
 
         data1a = list(zip(train_loader, range(3)))  # noqa: F841. Load 3 samples
@@ -197,7 +196,6 @@ class TestDataset(unittest.TestCase):
             ),
             checkpoint_every_sec=0,
             checkpoint_every_min_n_samples=1,
-            n_checkpoints=5,
         )
         train_loader.restore_state_rank(state1)
         data2_restore = list(zip(train_loader, range(5)))  # Load 5 samples

--- a/tests/test_metadataset_v2.py
+++ b/tests/test_metadataset_v2.py
@@ -357,7 +357,6 @@ class TestDataset(unittest.TestCase):
             train_dataset,
             checkpoint_every_sec=0,
             checkpoint_every_min_n_samples=1,
-            n_checkpoints=5,
         )
 
         data = list(zip(range(2 * 55), train_loader))
@@ -399,7 +398,6 @@ class TestDataset(unittest.TestCase):
             ),
             checkpoint_every_sec=0,
             checkpoint_every_min_n_samples=1,
-            n_checkpoints=5,
         )
 
         train_loader.restore_state_rank(state)
@@ -470,7 +468,6 @@ class TestDataset(unittest.TestCase):
             train_dataset,
             checkpoint_every_sec=0,
             checkpoint_every_min_n_samples=1,
-            n_checkpoints=5,
         )
 
         data = list(zip(range(2 * 55), train_loader))
@@ -551,7 +548,6 @@ class TestDataset(unittest.TestCase):
             train_dataset,
             checkpoint_every_sec=0,
             checkpoint_every_min_n_samples=1,
-            n_checkpoints=5,
         )
 
         data = list(zip(range(2 * 55), train_loader))
@@ -711,7 +707,6 @@ class TestDataset(unittest.TestCase):
             train_dataset,
             checkpoint_every_sec=0,
             checkpoint_every_min_n_samples=1,
-            n_checkpoints=5,
         )
 
         data = list(zip(range(2 * 55), train_loader))
@@ -828,7 +823,6 @@ class TestDataset(unittest.TestCase):
             train_dataset,
             checkpoint_every_sec=0,
             checkpoint_every_min_n_samples=1,
-            n_checkpoints=5,
         )
 
         data = list(enumerate(train_loader))
@@ -890,7 +884,6 @@ class TestDataset(unittest.TestCase):
             ),
             checkpoint_every_sec=0,
             checkpoint_every_min_n_samples=1,
-            n_checkpoints=5,
         )
         train_loader.restore_state_rank(state1)
         data2_restore = list(enumerate(train_loader))
@@ -966,7 +959,6 @@ class TestDataset(unittest.TestCase):
             train_dataset,
             checkpoint_every_sec=0,
             checkpoint_every_min_n_samples=1,
-            n_checkpoints=5,
         )
 
         data = list(enumerate(train_loader))
@@ -1003,7 +995,6 @@ class TestDataset(unittest.TestCase):
             ),
             checkpoint_every_sec=0,
             checkpoint_every_min_n_samples=1,
-            n_checkpoints=5,
         )
 
         data1 = list(zip(range(95), train_loader))
@@ -1022,7 +1013,6 @@ class TestDataset(unittest.TestCase):
             ),
             checkpoint_every_sec=0,
             checkpoint_every_min_n_samples=1,
-            n_checkpoints=5,
         )
         train_loader.restore_state_rank(state1)
         data2_restore = list(enumerate(train_loader))
@@ -1058,7 +1048,6 @@ class TestDataset(unittest.TestCase):
             ),
             checkpoint_every_sec=0,
             checkpoint_every_min_n_samples=1,
-            n_checkpoints=5,
         )
 
         ds1_counter = 0
@@ -1086,7 +1075,6 @@ class TestDataset(unittest.TestCase):
             ),
             checkpoint_every_sec=0,
             checkpoint_every_min_n_samples=1,
-            n_checkpoints=5,
         )
         train_loader.restore_state_rank(state1)
         data2_restore = list(enumerate(train_loader))


### PR DESCRIPTION
For some use cases, the user needs to fine tune the `prefetch_factor` argument of the underlying pytorch dataloader. This PR allows to specify the arg when calling `get_loader` or `get_savable_loader`