### PR TITLE
Fix docs sphinx build for Python 3.12

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,7 +59,7 @@ extensions = [
 autodoc_mock_imports = [
     "braceexpand",
     "fsspec",
-    "torch",
+    # "torch",
     "webdataset",
     "tqdm",
     "numpy",

--- a/src/megatron/energon/flavors/base_dataset.py
+++ b/src/megatron/energon/flavors/base_dataset.py
@@ -226,7 +226,7 @@ class State(ABC, ExtendableDataclassMixin):
     """
 
 
-class SavableDataset(IterableDataset[T_sample], Savable, Generic[T_sample], ABC):
+class SavableDataset(IterableDataset[T_sample], Savable, ABC):
     """A dataset that can be saved and restored (i.e. the random state, internal buffers, etc.).
     I.e. it can be resumed from a checkpoint.
 

--- a/src/megatron/energon/flavors/base_dataset.py
+++ b/src/megatron/energon/flavors/base_dataset.py
@@ -226,7 +226,7 @@ class State(ABC, ExtendableDataclassMixin):
     """
 
 
-class SavableDataset(IterableDataset[T_sample], Savable, ABC):
+class SavableDataset(IterableDataset[T_sample], Savable, Generic[T_sample], ABC):
     """A dataset that can be saved and restored (i.e. the random state, internal buffers, etc.).
     I.e. it can be resumed from a checkpoint.
 


### PR DESCRIPTION
Python 3.12 got stricter wrt. generics. In sphinx autodoc, we are using mocks for torch, but the mocked classes won't have the correct generics, so inheriting from them will raise an error.
We can

- either include the real real torch package without mocks
- or provide a better mock with the correct generics