### PR TITLE
Fastseek Fallback to Probe Mode

### DIFF
--- a/src/megatron/energon/av/av_decoder.py
+++ b/src/megatron/energon/av/av_decoder.py
@@ -14,7 +14,6 @@ try:
     import av
     import av.container
     import filetype
-
     from megatron.energon.av.fastseek import Fastseek
 
     AV_DECODE_AVAILABLE = True
@@ -48,7 +47,10 @@ class AVDecoder:
     @property
     def seeker(self) -> Fastseek:
         if self._seeker is None:
-            self._seeker = Fastseek(self.stream)
+            try:
+                self._seeker = Fastseek(self.stream)
+            except ValueError:
+                self._seeker = Fastseek(self.stream, probe=True)
         return self._seeker
 
     def get_video(self) -> AVData:

--- a/src/megatron/energon/av/fastseek/containers/probe.py
+++ b/src/megatron/energon/av/fastseek/containers/probe.py
@@ -1,5 +1,3 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.
-# SPDX-License-Identifier: BSD-3-Clause
 import av
 from sortedcontainers import SortedList
 
@@ -9,14 +7,14 @@ from ..keyframeinfo import KeyframeInfo
 def parse_probe(file):
     keyframes = {}
     with av.open(file) as input_container:
-        for stream in range(len(input_container.streams.video)):
+        for stream_idx, stream in enumerate(input_container.streams.video):
             packet_pts = [
                 (index, p.pts)
-                for index, p in enumerate(input_container.demux(video=stream))
+                for index, p in enumerate(input_container.demux(video=stream_idx))
                 if p.is_keyframe
             ]
             packet_pts.sort(key=lambda x: x[1])
 
-            keyframes[stream] = SortedList([KeyframeInfo(*p) for p in packet_pts])
+            keyframes[stream.id] = SortedList([KeyframeInfo(*p) for p in packet_pts])
 
         return keyframes


### PR DESCRIPTION
This PR fixes an issue with videos that are in unsupported containers or containers which have slight deviations from the expected format. 

In these cases the default Fastseek mode, container parsing, will throw an exception on an unrecognized format. Here, we catch that exception and fallback to Fastseek's probe mode which will parse the packets of the video bitstream (not the container) using ffmpeg via pyav to find keyframe information.

This is much faster than decoding the video frames but is still slower than container parsing. If the probe mode also fails, we allow the exception to propagate to the Energon user (this is almost certainly a corrupted video).