### PR TITLE
Add watchdog feature

### DIFF
--- a/src/megatron/energon/task_encoder/base.py
+++ b/src/megatron/energon/task_encoder/base.py
@@ -49,6 +49,7 @@ from megatron.energon.wrappers import (
     ShuffleBufferDataset,
 )
 from megatron.energon.wrappers.repeat_dataset import RepeatDataset
+from megatron.energon.wrappers.watchdog_dataset import WatchdogDataset
 
 T = TypeVar("T")
 V = TypeVar("V")
@@ -503,6 +504,8 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
         shuffle_buffer_size: Optional[int] = None,
         blend_mode: DatasetBlendMode = DatasetBlendMode.NONE,
         repeat: bool = True,
+        watchdog_timeout_seconds: float = 60,
+        fail_on_timeout: bool = False,
     ) -> SavableDataset[T_batch]:
         """Combines train datasets to a single dataset."""
 
@@ -591,6 +594,13 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
             )
         if worker_config.should_log(level=1):
             dataset = LogSampleDataset(dataset, mode="train", worker_config=worker_config)
+
+        dataset = WatchdogDataset(
+            dataset,
+            worker_config=worker_config,
+            timeout_seconds=watchdog_timeout_seconds,
+            fail_on_timeout=fail_on_timeout,
+        )
         return dataset
 
     def build_val_datasets(
@@ -602,6 +612,8 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
         batch_drop_last: bool = False,
         packing_buffer_size: Optional[int] = None,
         limit: Optional[int] = None,
+        watchdog_timeout_seconds: float = 60,
+        fail_on_timeout: bool = False,
     ) -> SavableDataset[T_batch]:
         """Combines val datasets to a single dataset."""
 
@@ -637,6 +649,12 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
             )
         if worker_config.should_log(level=2):
             dataset = LogSampleDataset(dataset, mode="val", worker_config=worker_config)
+        dataset = WatchdogDataset(
+            dataset,
+            worker_config=worker_config,
+            timeout_seconds=watchdog_timeout_seconds,
+            fail_on_timeout=fail_on_timeout,
+        )
         return dataset
 
     @property

--- a/src/megatron/energon/task_encoder/loader.py
+++ b/src/megatron/energon/task_encoder/loader.py
@@ -48,6 +48,8 @@ def get_train_dataset(
     shuffle_over_epochs_multiplier: Optional[int] = 1,
     task_encoder: TaskEncoder[Any, Any, Any, T] = DefaultTaskEncoder(),
     repeat: bool = True,
+    watchdog_timeout_seconds: float = 60,
+    fail_on_timeout: bool = False,
     **kwargs,
 ) -> SavableDataset[T]:
     """
@@ -109,6 +111,8 @@ def get_train_dataset(
         shuffle_buffer_size=shuffle_buffer_size,
         blend_mode=blend_mode,
         repeat=repeat,
+        watchdog_timeout_seconds=watchdog_timeout_seconds,
+        fail_on_timeout=fail_on_timeout,
     )
 
 
@@ -121,6 +125,8 @@ def get_val_dataset(
     batch_drop_last: bool = False,
     packing_buffer_size: Optional[int] = None,
     limit: Optional[int] = None,
+    watchdog_timeout_seconds: float = 60,
+    fail_on_timeout: bool = False,
     task_encoder: TaskEncoder[Any, Any, Any, T] = DefaultTaskEncoder(),
     **kwargs,
 ) -> SavableDataset[T]:
@@ -166,6 +172,8 @@ def get_val_dataset(
         batch_drop_last=batch_drop_last,
         packing_buffer_size=packing_buffer_size,
         limit=limit,
+        watchdog_timeout_seconds=watchdog_timeout_seconds,
+        fail_on_timeout=fail_on_timeout,
     )
 
 
@@ -178,6 +186,8 @@ def get_val_datasets(
     batch_drop_last: bool = False,
     packing_buffer_size: Optional[int] = None,
     limit: Optional[int] = None,
+    watchdog_timeout_seconds: float = 60,
+    fail_on_timeout: bool = False,
     task_encoder: TaskEncoder[Any, Any, Any, T] = DefaultTaskEncoder(),
     **kwargs,
 ) -> List[Tuple[SavableDataset[T], BaseCoreDatasetFactory]]:
@@ -225,6 +235,8 @@ def get_val_datasets(
                 batch_drop_last=batch_drop_last,
                 packing_buffer_size=packing_buffer_size,
                 limit=limit,
+                watchdog_timeout_seconds=watchdog_timeout_seconds,
+                fail_on_timeout=fail_on_timeout,
             ),
             dataset,
         )

--- a/src/megatron/energon/watchdog.py
+++ b/src/megatron/energon/watchdog.py
@@ -1,0 +1,288 @@
+import inspect
+import linecache
+import os
+import sys
+import threading
+import time
+import traceback
+from time import perf_counter
+from typing import Any, Callable, Iterable, Iterator, Optional, TypeVar
+
+T = TypeVar("T")  # for the watch_iter type
+
+
+class Watchdog:
+    """
+    A watchdog timer that:
+      - can be 'enabled' or 'disabled' by presence/absence of a deadline,
+      - resets automatically when 'enable()' is called,
+      - can be used as a context manager,
+      - can wrap an iterator to watch only the time for 'next()' calls,
+      - attempts a two-phase shutdown on callback error:
+         1) sys.exit(1) for graceful,
+         2) if still alive after 10s, os._exit(1).
+    """
+
+    def __init__(
+        self,
+        timeout: float,
+        callback: Optional[Callable[[], None]] = None,
+        dump_stacks: bool = True,
+        enabled: bool = True,
+    ) -> None:
+        """
+        :param timeout: Number of seconds before the watchdog fires if not reset/disabled.
+        :param callback: Optional function to call upon timeout.
+        :param dump_stacks: If True, print full stack traces for all threads on timeout (except watchdog's own thread).
+        :param enabled: If False, watchdog starts disabled until enable() is called.
+        """
+        self._timeout = timeout
+        self._callback = callback
+        self._dump_stacks = dump_stacks
+
+        # If _deadline is None, the watchdog is disabled.
+        # Otherwise, _deadline = time.time() + _timeout if enabled.
+        self._deadline: Optional[float] = perf_counter() + timeout if enabled else None
+
+        self._stop = False  # signals permanent shutdown (finish)
+
+        # Condition variable to manage state changes
+        self._cv = threading.Condition()
+        # Background thread (daemon) that monitors timeouts
+        self._worker_thread = threading.Thread(target=self._worker, daemon=True)
+        self._worker_thread.start()
+
+    def _worker(self) -> None:
+        """
+        Background thread that periodically checks if the watchdog has expired.
+        Once it times out or is told to stop, it exits.
+        """
+        while True:
+            with self._cv:
+                if self._stop:
+                    # finish() was called; end the worker.
+                    return
+
+                if self._deadline is None:
+                    # Disabled; no deadline. Just wait a bit, then re-check.
+                    self._cv.wait(timeout=1.0)
+                    continue
+
+                remaining = self._deadline - perf_counter()
+                if remaining <= 0:
+                    # We have timed out
+                    self._trigger()
+                    return
+                else:
+                    # Wait until either the deadline or a state change
+                    self._cv.wait(timeout=remaining)
+
+    def _trigger(self) -> None:
+        """
+        Called exactly once if the watchdog times out.
+        1) Optionally dumps stacks,
+        2) Calls user callback,
+        3) If callback raises an error,
+           - print traceback,
+           - sys.exit(1),
+           - fallback to os._exit(1) after 10s if process not terminated.
+        """
+        watchdog_thread_id = threading.get_ident()
+
+        # 1) Dump stacks if requested
+        if self._dump_stacks:
+            print("Watchdog triggered: Dumping thread stacks")
+            self._print_all_thread_stacks(skip_thread_id=watchdog_thread_id)
+
+        # 2) Call user callback
+        if self._callback:
+            try:
+                self._callback()
+            except Exception:
+                # Print the traceback
+                traceback.print_exc()
+
+                # Start a background kill-switch after 10 seconds
+                def force_exit_after_delay() -> None:
+                    time.sleep(10)
+                    os._exit(1)
+
+                killer = threading.Thread(target=force_exit_after_delay, daemon=True)
+                killer.start()
+
+                # Attempt graceful shutdown
+                sys.exit(1)
+
+    def _print_all_thread_stacks(self, skip_thread_id: Optional[int] = None) -> None:
+        """
+        Dump stacks of all threads in a style reminiscent of py-spy, from
+        innermost (current) to outermost. Skip the watchdog's own thread if given.
+        """
+        frames = sys._current_frames()  # thread_id -> frame
+        # We gather known threads to print their names
+        all_threads = {t.ident: t for t in threading.enumerate()}
+
+        for thread_id, frame in frames.items():
+            if skip_thread_id is not None and thread_id == skip_thread_id:
+                continue
+
+            thread = all_threads.get(thread_id)
+            thread_name = thread.name if thread else f"Unknown-{thread_id}"
+            print(f'Thread {thread_id}: "{thread_name}"')
+
+            # Build the stack from current (innermost) to outermost
+            stack_frames = []
+            f = frame
+            while f is not None:
+                stack_frames.append(f)
+                f = f.f_back
+
+            for fr in stack_frames:
+                code = fr.f_code
+                func_name = code.co_name
+                filename = code.co_filename
+                lineno = fr.f_lineno
+
+                print(f"    {func_name} ({filename}:{lineno})")
+
+                # Attempt to read the actual line of source
+                line = linecache.getline(filename, lineno).rstrip()
+                if line:
+                    print(f"        > {line}")
+
+                # Show arguments and locals
+                arg_info = inspect.getargvalues(fr)
+                arg_names = arg_info.args
+                varargs = arg_info.varargs
+                varkw = arg_info.keywords
+                local_vars = arg_info.locals
+
+                # Separate out the arguments
+                arg_dict = {}
+                for arg in arg_names:
+                    if arg in local_vars:
+                        arg_dict[arg] = local_vars[arg]
+                if varargs and varargs in local_vars:
+                    arg_dict["*" + varargs] = local_vars[varargs]
+                if varkw and varkw in local_vars:
+                    arg_dict["**" + varkw] = local_vars[varkw]
+
+                if arg_dict:
+                    print("        Arguments:")
+                    for k, v in arg_dict.items():
+                        print(f"            {k}: {repr(v)}")
+
+                other_locals = {k: v for k, v in local_vars.items() if k not in arg_dict}
+                if other_locals:
+                    print("        Locals:")
+                    for k, v in other_locals.items():
+                        print(f"            {k}: {repr(v)}")
+
+            print()
+
+    # --------------------------------------------------------------------------
+    # Public API
+    # --------------------------------------------------------------------------
+
+    def reset(self) -> None:
+        """
+        Reset the watchdog timer (push out deadline by `timeout` seconds),
+        but only if currently enabled (i.e., _deadline is not None).
+        """
+        with self._cv:
+            if self._deadline is not None:
+                self._deadline = perf_counter() + self._timeout
+                self._cv.notify()
+
+    def enable(self) -> None:
+        """
+        Enable (or re-enable) the watchdog. Always resets the deadline to
+        `time.time() + timeout`.
+        """
+        with self._cv:
+            self._deadline = perf_counter() + self._timeout
+            self._cv.notify()
+
+    def disable(self) -> None:
+        """
+        Disable the watchdog (no timeout will fire until re-enabled).
+        """
+        with self._cv:
+            self._deadline = None
+            self._cv.notify()
+
+    def finish(self) -> None:
+        """
+        Permanently stop the watchdog thread and disarm the timer.
+        After calling finish(), you cannot re-enable this watchdog.
+        """
+        with self._cv:
+            self._stop = True
+            self._cv.notify()
+        self._worker_thread.join()
+
+    # --------------------------------------------------------------------------
+    # Context manager support
+    # --------------------------------------------------------------------------
+
+    def __enter__(self) -> "Watchdog":
+        # If currently disabled, calling enable() will also reset the timer
+        if self._deadline is None:
+            self.enable()
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        # End the watchdog on context exit
+        self.finish()
+
+    # --------------------------------------------------------------------------
+    # Iterator wrapper
+    # --------------------------------------------------------------------------
+
+    def watch_iter(self, iterable: Iterable[T]) -> Iterator[T]:
+        """
+        Wrap an iterable so that each 'next()' call is watched by the watchdog,
+        but the time in between iterations is not watched. Usage:
+
+            wd = Watchdog(timeout=3, enabled=False)
+            for item in wd.watch_iter(generator()):
+                # processing item not timed by the watchdog
+                pass
+
+        This pattern:
+          - enable() -> sets/extends deadline
+          - next(...) -> measured portion
+          - disable() -> stops timer
+        """
+        it = iter(iterable)
+        while True:
+            self.enable()  # automatically resets timer
+            try:
+                item = next(it)
+            except StopIteration:
+                self.disable()
+                break
+            except:
+                # On any error, disable watchdog before re-raising
+                self.disable()
+                raise
+            else:
+                self.disable()
+                yield item
+
+
+if __name__ == "__main__":
+    # Example usage
+
+    def my_callback() -> None:
+        print("Watchdog timed out in callback.")
+        # Demonstrate an error
+        raise ValueError("Example error from callback.")
+
+    print("Simple usage example:")
+    wd = Watchdog(timeout=2, callback=my_callback, enabled=True)
+    print("Sleeping 3s so the watchdog times out.")
+    time.sleep(30)
+    # Because we never reset or finish, the watchdog should fire and
+    # forcibly exit, after printing the traceback and stack dumps.
+    print("You won't see this line if the watchdog fired first.")

--- a/src/megatron/energon/wrappers/watchdog_dataset.py
+++ b/src/megatron/energon/wrappers/watchdog_dataset.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import warnings
+from typing import Any, Dict, Generic, Iterator, TypeVar
+
+from megatron.energon.flavors.base_dataset import SavableDataset
+from megatron.energon.watchdog import Watchdog
+from megatron.energon.worker import WorkerConfig
+from megatron.energon.wrappers.base import BaseWrapperDataset
+
+T_sample = TypeVar("T_sample")
+
+
+class WatchdogDataset(BaseWrapperDataset[T_sample, T_sample], Generic[T_sample]):
+    """This dataset wraps another dataset and watches the time it takes to yield samples."""
+
+    def __init__(
+        self,
+        dataset: SavableDataset[T_sample],
+        worker_config: WorkerConfig,
+        timeout_seconds: float = 60,
+        fail_on_timeout: bool = False,
+    ):
+        """Construct the watchdog dataset, which wraps another dataset and watches
+        the time it takes to yield samples from the wrapped dataset.
+
+        Args:
+            dataset: The input dataset to wrap
+            worker_config: The worker configuration
+        """
+        super().__init__(dataset, worker_config=worker_config)
+        self.timeout_seconds = timeout_seconds
+        self.fail_on_timeout = fail_on_timeout
+
+    def reset_state_own(self) -> None:
+        pass
+
+    def __len__(self):
+        return len(self.dataset)
+
+    def _watchdog_trigger(self) -> None:
+        if self.fail_on_timeout:
+            # Raising an exception here will kill the whole process
+            raise TimeoutError(
+                f"Watchdog triggered. Sample processing took longer than {self.timeout_seconds} seconds."
+            )
+        else:
+            warnings.warn(
+                f"Watchdog triggered. Sample processing took longer than {self.timeout_seconds} seconds.",
+                RuntimeWarning,
+            )
+
+    def __iter__(self) -> Iterator[T_sample]:
+        watchdog = Watchdog(
+            timeout=self.timeout_seconds, callback=self._watchdog_trigger, enabled=False
+        )
+        yield from watchdog.watch_iter(self.dataset)
+
+    def config(self) -> Dict[str, Any]:
+        # Transparent logger, it won't change the samples
+        return self.dataset.config()
+
+    def __str__(self):
+        return f"WatchdogDataset(dataset={self.dataset})"

--- a/tests/test_metadataset_v2.py
+++ b/tests/test_metadataset_v2.py
@@ -13,6 +13,7 @@ import warnings
 from collections import Counter
 from pathlib import Path
 from typing import Iterable
+from unittest.mock import patch
 
 import torch
 import webdataset as wds
@@ -31,6 +32,8 @@ from megatron.energon.epathlib.epath import EPath
 from megatron.energon.flavors.webdataset import MAIN_FOLDER_NAME
 from megatron.energon.metadataset.loader import prepare_metadataset
 from megatron.energon.metadataset.loader_interface import DatasetBlendMode
+from megatron.energon.task_encoder.base import DefaultTaskEncoder
+from megatron.energon.wrappers.watchdog_dataset import WatchdogDataset
 
 
 def _norng_state(state):
@@ -1094,6 +1097,52 @@ class TestDataset(unittest.TestCase):
         assert sample_counts_save_restore == sample_counts, (
             "Sample counts do not match when using save/restore"
         )
+
+    @patch.object(WatchdogDataset, "_watchdog_trigger")
+    def test_watchdog_dataset(self, mock_watchdog_trigger):
+        class TestTaskEncoder(DefaultTaskEncoder):
+            def __init__(self):
+                super().__init__()
+                self.did_sleep = False
+
+            def encode_sample(self, sample: TextSample) -> TextSample:
+                if sample.text == "13":
+                    import time
+
+                    if not self.did_sleep:
+                        print("Sleeping for 5 seconds on encode_sample to simulate stuck worker")
+                        time.sleep(5)
+                        self.did_sleep = True
+
+                return sample
+
+        worker_config = WorkerConfig(
+            rank=0,
+            world_size=1,
+            num_workers=0,
+            seed_offset=42,
+        )
+
+        # Train mode dataset
+        train_dataset = get_train_dataset(
+            self.mds_path,
+            worker_config=worker_config,
+            batch_size=1,
+            shuffle_buffer_size=None,
+            max_samples_per_sequence=None,
+            task_encoder=TestTaskEncoder(),
+            watchdog_timeout_seconds=3,
+            fail_on_timeout=False,
+        )
+
+        train_loader = get_loader(train_dataset)
+
+        for idx, data in enumerate(train_loader):
+            print(idx, data.text[0])
+            if idx > 255:
+                break
+
+        mock_watchdog_trigger.assert_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
With this PR, a watchdog will check the time taken for each iterated sample. I.e. not the time of the outer loop, but the time it takes to retrieve and encode the sample including the `TaskEncoder` code.
If that time exceeds 60 seconds, a warning with traceback is printed. The time limit is configurable and there's an option to completely shut down the process in this case.