### PR TITLE
AVDecoder: Separate audio and video duration methods

### DIFF
--- a/src/megatron/energon/av/av_decoder.py
+++ b/src/megatron/energon/av/av_decoder.py
@@ -25,13 +25,6 @@ except ImportError as e:
 from megatron.energon.av.av_data import AVData
 
 
-def initialize_av_container(input_container: av.container.InputContainer) -> None:
-    for stream in input_container.streams:
-        cc = stream.codec_context
-        cc.thread_type = "NONE"
-        cc.thread_count = 0
-
-
 class AVDecoder:
     """A class that provides a flexible interface for decoding audio and video data.
 
@@ -655,3 +648,18 @@ class AVWebdatasetDecoder:
             )
         else:
             raise ValueError(f"Invalid av_decode value: {self.av_decode}")
+
+
+def initialize_av_container(input_container: av.container.InputContainer) -> None:
+    """Every PyAV container should be initialized with this function.
+
+    This function ensures that no additional threads are created.
+    This is to avoid deadlocks in ffmpeg when when deallocating the container.
+    Furthermore, we cannot have multiple threads before forking the process when
+    using torch data loaders with multiple workers.
+    """
+
+    for stream in input_container.streams:
+        cc = stream.codec_context
+        cc.thread_type = "NONE"
+        cc.thread_count = 0

--- a/src/megatron/energon/av/av_decoder.py
+++ b/src/megatron/energon/av/av_decoder.py
@@ -538,7 +538,6 @@ class AVDecoder:
                     video_start_pts = 0.0
 
                 video_duration = video_stream.duration
-                print(f"Video duration: {video_duration}")
 
             if video_duration is None:
                 # If duration isn't found in header the whole video is decoded to

--- a/src/megatron/energon/av/utils.py
+++ b/src/megatron/energon/av/utils.py
@@ -58,7 +58,7 @@ def get_clips_uniform(
         # Special case of single frames: End point should be start of last frame
         video_fps = av_decoder.get_video_fps()
         video_spf = 1 / video_fps
-        last_start_time = total_duration - video_spf * 1.5
+        last_start_time = total_duration - video_spf * 0.9
     else:
         last_start_time = total_duration - clip_duration_seconds
     clips = [

--- a/src/megatron/energon/av/utils.py
+++ b/src/megatron/energon/av/utils.py
@@ -35,7 +35,24 @@ def get_clips_uniform(
     if not request_video and not request_audio:
         raise ValueError("You must request at least one of video or audio")
 
-    total_duration, _ = av_decoder.get_duration()
+    video_duration = float("inf")
+    audio_duration = float("inf")
+
+    if request_video:
+        video_duration, _ = av_decoder.get_video_duration()
+        if video_duration is None:
+            raise ValueError("No video duration found")
+
+    if request_audio:
+        audio_duration = av_decoder.get_audio_duration()
+        if audio_duration is None:
+            raise ValueError("No audio duration found")
+
+    # Typically, audio and video don't have the exact same duration, so we take the minimum
+    # so that we can safely extract clips of equal duration.
+    total_duration = min(video_duration, audio_duration)
+
+    assert total_duration != float("inf")
 
     if clip_duration_seconds == 0:
         # Special case of single frames: End point should be start of last frame

--- a/tests/test_av_decoder.py
+++ b/tests/test_av_decoder.py
@@ -304,7 +304,7 @@ class TestAudioDecode(unittest.TestCase):
             audio_tensor.shape == av_data.audio_clips[0].shape
             for audio_tensor in av_data.audio_clips
         ), "Audio clips have different shapes"
-    
+
     def test_wav_decode_against_soundfile(self):
         """Test decoding a WAV file against the soundfile library."""
 

--- a/tests/test_av_decoder.py
+++ b/tests/test_av_decoder.py
@@ -75,23 +75,8 @@ class TestVideoDecode(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        import inspect
-
-        import psutil
-
-        print(
-            f"Threads at line {inspect.currentframe().f_lineno}:",
-            [thread.id for thread in psutil.Process().threads()],
-        )
-
         logging.basicConfig(stream=sys.stderr, level=logging.INFO)
         self.decode_baseline_video_pyav()
-
-        print(
-            f"Threads at line {inspect.currentframe().f_lineno}:",
-            [thread.id for thread in psutil.Process().threads()],
-        )
-
         self.loaders = []  # Keep track of loaders for cleanup
 
     def tearDown(self):
@@ -151,27 +136,11 @@ class TestVideoDecode(unittest.TestCase):
 
     def test_video_audio_sync(self):
         """Test decoding video frames and audio clips together."""
-        import inspect
-
-        import psutil
-
-        print(
-            f"Threads at line {inspect.currentframe().f_lineno}:",
-            [thread.id for thread in psutil.Process().threads()],
-        )
-
-        print_python_thread_stacks()
-
         with open("tests/data/sync_test.mp4", "rb") as f:
             raw_bytes = f.read()
             stream = io.BytesIO(raw_bytes)
 
         av_decoder = AVDecoder(stream)
-
-        print(
-            f"Threads at line {inspect.currentframe().f_lineno}:",
-            [thread.id for thread in psutil.Process().threads()],
-        )
 
         # Extract a single frame every 2 seconds and an audio clip (0.05 seconds long) at the same time.
         # We extract the frames from the sync video that shows the full white circle on the left,
@@ -184,11 +153,6 @@ class TestVideoDecode(unittest.TestCase):
             video_unit="seconds",
             audio_unit="seconds",
             video_out_frame_size=None,
-        )
-
-        print(
-            f"Threads at line {inspect.currentframe().f_lineno}:",
-            [thread.id for thread in psutil.Process().threads()],
         )
 
         # We drop the first two extracted frames because the click sequence hasn't started yet
@@ -208,11 +172,6 @@ class TestVideoDecode(unittest.TestCase):
 
         # Check that the first audio clip has the click sound
         assert (audio_clips[0] > 0.5).any(), "Audio click not found"
-
-        print(
-            f"Threads at line {inspect.currentframe().f_lineno}:",
-            [thread.id for thread in psutil.Process().threads()],
-        )
 
         # Check that all the audio clips are the same (close value)
         for audio_clip in audio_clips:

--- a/tests/test_av_decoder.py
+++ b/tests/test_av_decoder.py
@@ -34,6 +34,11 @@ def load_video_to_tensor(video_path: str) -> torch.Tensor:
         Tensor of shape [num_frames, channels, height, width]
     """
     container = av.open(video_path)
+    for stream in container.streams:
+        cc = stream.codec_context
+        cc.thread_type = "NONE"
+        cc.thread_count = 0
+
     frames = []
 
     for frame in container.decode(video=0):
@@ -70,8 +75,23 @@ class TestVideoDecode(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
+        import inspect
+
+        import psutil
+
+        print(
+            f"Threads at line {inspect.currentframe().f_lineno}:",
+            [thread.id for thread in psutil.Process().threads()],
+        )
+
         logging.basicConfig(stream=sys.stderr, level=logging.INFO)
         self.decode_baseline_video_pyav()
+
+        print(
+            f"Threads at line {inspect.currentframe().f_lineno}:",
+            [thread.id for thread in psutil.Process().threads()],
+        )
+
         self.loaders = []  # Keep track of loaders for cleanup
 
     def tearDown(self):
@@ -131,11 +151,27 @@ class TestVideoDecode(unittest.TestCase):
 
     def test_video_audio_sync(self):
         """Test decoding video frames and audio clips together."""
+        import inspect
+
+        import psutil
+
+        print(
+            f"Threads at line {inspect.currentframe().f_lineno}:",
+            [thread.id for thread in psutil.Process().threads()],
+        )
+
+        print_python_thread_stacks()
+
         with open("tests/data/sync_test.mp4", "rb") as f:
             raw_bytes = f.read()
             stream = io.BytesIO(raw_bytes)
 
         av_decoder = AVDecoder(stream)
+
+        print(
+            f"Threads at line {inspect.currentframe().f_lineno}:",
+            [thread.id for thread in psutil.Process().threads()],
+        )
 
         # Extract a single frame every 2 seconds and an audio clip (0.05 seconds long) at the same time.
         # We extract the frames from the sync video that shows the full white circle on the left,
@@ -148,6 +184,11 @@ class TestVideoDecode(unittest.TestCase):
             video_unit="seconds",
             audio_unit="seconds",
             video_out_frame_size=None,
+        )
+
+        print(
+            f"Threads at line {inspect.currentframe().f_lineno}:",
+            [thread.id for thread in psutil.Process().threads()],
         )
 
         # We drop the first two extracted frames because the click sequence hasn't started yet
@@ -167,6 +208,11 @@ class TestVideoDecode(unittest.TestCase):
 
         # Check that the first audio clip has the click sound
         assert (audio_clips[0] > 0.5).any(), "Audio click not found"
+
+        print(
+            f"Threads at line {inspect.currentframe().f_lineno}:",
+            [thread.id for thread in psutil.Process().threads()],
+        )
 
         # Check that all the audio clips are the same (close value)
         for audio_clip in audio_clips:


### PR DESCRIPTION
Joint audio/video duration is inaccurate, which is a problem for the last frame when extracting frames uniformly.