### PR TITLE
Add More Fallback Logic to Fastseek

### DIFF
--- a/src/megatron/energon/av/av_decoder.py
+++ b/src/megatron/energon/av/av_decoder.py
@@ -14,7 +14,6 @@ try:
     import av
     import av.container
     import filetype
-
     from megatron.energon.av.fastseek import Fastseek
 
     AV_DECODE_AVAILABLE = True
@@ -46,7 +45,7 @@ class AVDecoder:
 
         try:
             self.seeker = Fastseek(self.stream)
-        except ValueError:
+        except Exception:
             self.seeker = Fastseek(self.stream, probe=True)
 
         self.stream.seek(0)

--- a/src/megatron/energon/av/fastseek/fastseek.py
+++ b/src/megatron/energon/av/fastseek/fastseek.py
@@ -66,6 +66,11 @@ class Fastseek:
                     f"Unsupported container: {ftype.mime} (hint: try passing probe=True to the Fastseek constructor)"
                 )
 
+            if len(self.keyframes) == 0:
+                raise ValueError(
+                    f"The parser for {ftype.mime} was unable to find keyframes (hint: try passing probe=True to the Fastseek constructor)"
+                )
+
     def should_seek(self, current: int, target: int, stream: int = 0) -> Optional[KeyframeInfo]:
         """Determine if seeking to a keyframe is necessary to reach the target frame.
 


### PR DESCRIPTION
Certain malformed mp4 files can yield empty keyframe lists or trigger random parse errors

This PR explicitly catches the empty keyframe list issue and also falls back to probe mode if any type of exception is thrown during parsing