### PR TITLE
Add More Fallback Logic to Fastseek

### DIFF
--- a/src/megatron/energon/av/av_decoder.py
+++ b/src/megatron/energon/av/av_decoder.py
@@ -14,7 +14,6 @@ try:
     import av
     import av.container
     import filetype
-
     from megatron.energon.av.fastseek import Fastseek
 
     AV_DECODE_AVAILABLE = True
@@ -661,5 +660,7 @@ def initialize_av_container(input_container: av.container.InputContainer) -> Non
 
     for stream in input_container.streams:
         cc = stream.codec_context
-        cc.thread_type = "NONE"
-        cc.thread_count = 0
+
+        if cc is not None:
+            cc.thread_type = "NONE"
+            cc.thread_count = 0

--- a/src/megatron/energon/av/av_decoder.py
+++ b/src/megatron/energon/av/av_decoder.py
@@ -14,6 +14,7 @@ try:
     import av
     import av.container
     import filetype
+
     from megatron.energon.av.fastseek import Fastseek
 
     AV_DECODE_AVAILABLE = True

--- a/src/megatron/energon/av/av_decoder.py
+++ b/src/megatron/energon/av/av_decoder.py
@@ -14,7 +14,6 @@ try:
     import av
     import av.container
     import filetype
-
     from megatron.energon.av.fastseek import Fastseek
 
     AV_DECODE_AVAILABLE = True
@@ -46,7 +45,7 @@ class AVDecoder:
 
         try:
             self.seeker = Fastseek(self.stream)
-        except ValueError:
+        except Exception:
             self.seeker = Fastseek(self.stream, probe=True)
 
         self.stream.seek(0)

--- a/src/megatron/energon/av/av_decoder.py
+++ b/src/megatron/energon/av/av_decoder.py
@@ -13,7 +13,6 @@ import torch
 try:
     import av
     import av.container
-    import bitstring
     import filetype
 
     from megatron.energon.av.fastseek import Fastseek

--- a/src/megatron/energon/av/av_decoder.py
+++ b/src/megatron/energon/av/av_decoder.py
@@ -13,6 +13,7 @@ import torch
 try:
     import av
     import av.container
+    import bitstring
     import filetype
 
     from megatron.energon.av.fastseek import Fastseek
@@ -46,7 +47,7 @@ class AVDecoder:
 
         try:
             self.seeker = Fastseek(self.stream)
-        except Exception:
+        except (ValueError, IndexError, bitstring.Error, KeyError, IOError, TypeError):
             self.stream.seek(0)
             self.seeker = Fastseek(self.stream, probe=True)
 

--- a/src/megatron/energon/av/av_decoder.py
+++ b/src/megatron/energon/av/av_decoder.py
@@ -47,7 +47,7 @@ class AVDecoder:
 
         try:
             self.seeker = Fastseek(self.stream)
-        except (ValueError, IndexError, bitstring.Error, KeyError, IOError, TypeError):
+        except ValueError:
             self.stream.seek(0)
             self.seeker = Fastseek(self.stream, probe=True)
 

--- a/src/megatron/energon/av/av_decoder.py
+++ b/src/megatron/energon/av/av_decoder.py
@@ -14,7 +14,6 @@ try:
     import av
     import av.container
     import filetype
-
     from megatron.energon.av.fastseek import Fastseek
 
     AV_DECODE_AVAILABLE = True
@@ -47,6 +46,7 @@ class AVDecoder:
         try:
             self.seeker = Fastseek(self.stream)
         except Exception:
+            self.stream.seek(0)
             self.seeker = Fastseek(self.stream, probe=True)
 
         self.stream.seek(0)

--- a/src/megatron/energon/av/fastseek/containers/matroska.py
+++ b/src/megatron/energon/av/fastseek/containers/matroska.py
@@ -31,8 +31,11 @@ class CuePoint:
 
 
 def parse_matroska(file: BitsType) -> SortedList:
-    schema = loadSchema("matroska.xml")
-    doc = schema.load(file, headers=True)
+    try:
+        schema = loadSchema("matroska.xml")
+        doc = schema.load(file, headers=True)
+    except (KeyError, IOError, TypeError) as e:
+        raise ValueError(f"Matroska parsing failed with error {e}")
 
     # Get cue times
     stack = [c for c in doc if c.name == "Segment"]

--- a/src/megatron/energon/av/fastseek/fastseek.py
+++ b/src/megatron/energon/av/fastseek/fastseek.py
@@ -66,6 +66,11 @@ class Fastseek:
                     f"Unsupported container: {ftype.mime} (hint: try passing probe=True to the Fastseek constructor)"
                 )
 
+            if len(self.keyframes) == 0:
+                raise ValueError(
+                    f"The parser for {ftype.mime} was unable to find keyframes (hint: try passing probe=True to the Fastseek constructor)"
+                )
+
     def should_seek(self, current: int, target: int, stream: int = 0) -> Optional[KeyframeInfo]:
         """Determine if seeking to a keyframe is necessary to reach the target frame.
 


### PR DESCRIPTION
Certain malformed mp4 files can yield empty keyframe lists or trigger random parse errors

This PR explicitly catches the empty keyframe list issue and also falls back to probe mode if any type of exception is thrown during parsing
