### PR TITLE
Fix Save - Restore indexing

### DIFF
--- a/src/megatron/energon/rng.py
+++ b/src/megatron/energon/rng.py
@@ -3,7 +3,7 @@
 
 import hashlib
 import random
-from typing import Any, List, Optional, TypeVar
+from typing import Any, List, Mapping, Optional, Sequence, TypeVar
 
 import numpy
 import torch
@@ -97,8 +97,25 @@ class SystemRngState:
     numpy: Any  # Currently `dict[str, Any] | tuple[str, NDArray[uint32], int, int, float]`
     random: Any  # Currently a nested tuple
 
+    def _hashable_value(self, value: Any) -> tuple | int | float | bool | str:
+        if isinstance(value, (int, float, bool, str)) or value is None:
+            return value
+        elif isinstance(value, torch.Tensor):
+            return self._hashable_value(value.tolist())
+        elif isinstance(value, numpy.ndarray):
+            return self._hashable_value(value.tolist())
+        elif isinstance(value, Mapping):
+            return tuple(
+                (self._hashable_value(k), self._hashable_value(v)) for k, v in value.items()
+            )
+        elif isinstance(value, Sequence):
+            return tuple(self._hashable_value(v) for v in value)
+        else:
+            raise ValueError(f"Cannot hash value of type {type(value)}: {value!r}")
+
     def __repr__(self):
-        return f"SystemRngState(torch={self.torch[:3]}..., numpy={self.numpy!r}, random={self.random!r})"
+        # If the hash is the same, the state is the same. Should suffice to identify the state.
+        return f"SystemRngState(hash={hash(self._hashable_value((self.torch, self.numpy, self.random)))})"
 
 
 class SystemRng:

--- a/src/megatron/energon/rng.py
+++ b/src/megatron/energon/rng.py
@@ -97,7 +97,7 @@ class SystemRngState:
     numpy: Any  # Currently `dict[str, Any] | tuple[str, NDArray[uint32], int, int, float]`
     random: Any  # Currently a nested tuple
 
-    def _hashable_value(self, value: Any) -> tuple | int | float | bool | str:
+    def _hashable_value(self, value: Any) -> Any:
         if isinstance(value, (int, float, bool, str)) or value is None:
             return value
         elif isinstance(value, torch.Tensor):

--- a/src/megatron/energon/worker.py
+++ b/src/megatron/energon/worker.py
@@ -168,9 +168,12 @@ class WorkerConfig:
         if worker_info is None:
             return self.worker_id_offset
         assert worker_info.num_workers == self.num_workers
-        return (
-            worker_info.id + worker_info.num_workers - self.worker_id_offset
-        ) % worker_info.num_workers
+        # Apply the worker_id_offset as a left rotation of the logical worker ids.
+        # This ensures that after restoring a checkpoint the first physical
+        # worker (id=0) corresponds to the logical worker that should emit the
+        # next sample. For example, if `worker_id_offset` is 1, logical worker
+        # 1 becomes the first to emit a sample, shifting the ordering forward.
+        return (worker_info.id + self.worker_id_offset) % worker_info.num_workers
 
     def assert_worker(self):
         """Checks if the current process is a worker (if configured so), and that the workers are

--- a/tests/test_crudedataset.py
+++ b/tests/test_crudedataset.py
@@ -31,6 +31,13 @@ from megatron.energon.dataclass_slots import dataclass_slots
 from megatron.energon.flavors.webdataset import MAIN_FOLDER_NAME
 from megatron.energon.flavors.webdataset.structs import reraise_exception
 
+# Speed up tests significantly by reducing the torch status check interval for broken worker shutdown
+try:
+    torch.utils.data._utils.worker.MP_STATUS_CHECK_INTERVAL = 0.1
+    torch.utils.data._utils.MP_STATUS_CHECK_INTERVAL = 0.1
+except AttributeError:
+    pass
+
 
 @dataclass_slots
 class TextBatch(Batch):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -54,6 +54,14 @@ from megatron.energon.tools.lint import command as lint_command
 from megatron.energon.tools.prepare import command as prepare_command
 from megatron.energon.tools.preview import command as preview_command
 
+# Speed up tests significantly by reducing the torch status check interval for broken worker shutdown
+try:
+    torch.utils.data._utils.worker.MP_STATUS_CHECK_INTERVAL = 0.1
+    torch.utils.data._utils.MP_STATUS_CHECK_INTERVAL = 0.1
+except AttributeError:
+    pass
+
+
 DATASET_SIZE = 50
 
 no_worker_config = WorkerConfig(rank=0, world_size=1, num_workers=0)

--- a/tests/test_dataset_det.py
+++ b/tests/test_dataset_det.py
@@ -30,6 +30,13 @@ from megatron.energon.loader import get_savable_loader
 from megatron.energon.task_encoder.base import stateless
 from megatron.energon.tools.checkpoint import command_redist
 
+# Speed up tests significantly by reducing the torch status check interval for broken worker shutdown
+try:
+    torch.utils.data._utils.worker.MP_STATUS_CHECK_INTERVAL = 0.1
+    torch.utils.data._utils.MP_STATUS_CHECK_INTERVAL = 0.1
+except AttributeError:
+    pass
+
 
 def _norng_state(state):
     if isinstance(state, bytes):

--- a/tests/test_metadataset.py
+++ b/tests/test_metadataset.py
@@ -1247,12 +1247,31 @@ class TestDataset(unittest.TestCase):
         )
         skip_initial = 9
 
+        previous_cp = initial_loader.save_state_rank()
+        print("initial_samples:")
+        for i, sample in zip(range(skip_initial), initial_loader):
+            print(f"sample[@{i}]: {sample.text}")
+            print("previous_cp:", previous_cp)
+            rst_loader = get_savable_loader(
+                get_train_dataset(
+                    self.nested_mds_path,
+                    worker_config=wc,
+                    batch_size=1,
+                    shuffle_buffer_size=None,
+                    max_samples_per_sequence=None,
+                ),
+                checkpoint_every_sec=0,
+                checkpoint_every_min_n_samples=0,
+            )
+            rst_loader.restore_state_rank(previous_cp)
+            for i, rst_sample in zip(range(1), rst_loader):
+                print(f"rst_sample[@{i}]: {rst_sample.text}")
+            assert sample.text == rst_sample.text, f"{sample} != {rst_sample}"
+            assert sample.__key__ == rst_sample.__key__, f"{sample} != {rst_sample}"
+            assert sample.__restore_key__ == rst_sample.__restore_key__, f"{sample} != {rst_sample}"
+            previous_cp = initial_loader.save_state_rank()
+
         # Iterate 10 samples, the save state and store the next 10 samples for reference.
-        skip_samples = [sample for _, sample in zip(range(skip_initial), initial_loader)]
-        print(
-            "skip_samples:"
-            + "".join(f"\n [@{idx}] {sample.text}" for idx, sample in enumerate(skip_samples))
-        )
         state_initial = initial_loader.save_state_rank()
         print("state_initial:", str(state_initial))
         initial_samples = [sample for _, sample in zip(range(20), initial_loader)]

--- a/tests/test_metadataset.py
+++ b/tests/test_metadataset.py
@@ -30,6 +30,13 @@ from megatron.energon.flavors.webdataset import MAIN_FOLDER_NAME
 from megatron.energon.metadataset.loader_interface import DatasetBlendMode
 from megatron.energon.wrappers.blend_dataset import BlendDataset
 
+# Speed up tests significantly by reducing the torch status check interval for broken worker shutdown
+try:
+    torch.utils.data._utils.worker.MP_STATUS_CHECK_INTERVAL = 0.1
+    torch.utils.data._utils.MP_STATUS_CHECK_INTERVAL = 0.1
+except AttributeError:
+    pass
+
 
 def _norng_state(state):
     if isinstance(state, bytes):
@@ -1256,6 +1263,9 @@ class TestDataset(unittest.TestCase):
                 for idx, sample in enumerate(initial_samples, start=skip_initial)
             )
         )
+
+        del initial_loader
+        gc.collect()
 
         second_loader = get_savable_loader(
             get_train_dataset(

--- a/tests/test_metadataset.py
+++ b/tests/test_metadataset.py
@@ -1218,6 +1218,137 @@ class TestDataset(unittest.TestCase):
         loader = new_loader()
         _ = [data.text for idx, data in zip(range(1000), loader)]
 
+    def test_save_restore_next(self):
+        torch.manual_seed(42)
+
+        wc = WorkerConfig(
+            rank=0,
+            world_size=1,
+            num_workers=6,
+        )
+
+        initial_loader = get_savable_loader(
+            get_train_dataset(
+                self.nested_mds_path,
+                worker_config=wc,
+                batch_size=1,
+                shuffle_buffer_size=None,
+                max_samples_per_sequence=None,
+            ),
+            checkpoint_every_sec=0,
+            checkpoint_every_min_n_samples=0,
+        )
+        skip_initial = 9
+
+        # Iterate 10 samples, the save state and store the next 10 samples for reference.
+        skip_samples = [sample for _, sample in zip(range(skip_initial), initial_loader)]
+        print(
+            "skip_samples:"
+            + "".join(f"\n [@{idx}] {sample.text}" for idx, sample in enumerate(skip_samples))
+        )
+        state_initial = initial_loader.save_state_rank()
+        print("state_initial:", str(state_initial))
+        initial_samples = [sample for _, sample in zip(range(20), initial_loader)]
+        print(
+            "initial_samples:"
+            + "".join(
+                f"\n [@{idx}] {sample.text}"
+                for idx, sample in enumerate(initial_samples, start=skip_initial)
+            )
+        )
+
+        second_loader = get_savable_loader(
+            get_train_dataset(
+                self.nested_mds_path,
+                worker_config=wc,
+                batch_size=1,
+                shuffle_buffer_size=None,
+                max_samples_per_sequence=None,
+            ),
+            checkpoint_every_sec=0,
+            checkpoint_every_min_n_samples=0,
+        )
+        second_loader.restore_state_rank(state_initial)
+
+        # Save the state again, to check that it is the same as the just restored state
+        same_state = second_loader.save_state_rank()
+        print("same_state:", same_state)
+        assert same_state == state_initial
+
+        for offset in range(10):
+            try:
+                # Save state and restore in next loader
+                state_offset = second_loader.save_state_rank()
+                # Get 1 sample from the current loader
+                samples = [sample for _, sample in zip(range(1), second_loader)]
+                assert len(samples) == 1
+                sample = samples[0]
+
+                # Check that the sample is the same as the initial loader's reference sample
+                print(f"sample[@{offset + skip_initial}]: {sample.text}")
+                try:
+                    assert sample.text == initial_samples[offset].text, (
+                        f"{sample} != {initial_samples[offset]}"
+                    )
+                    assert sample.__key__ == initial_samples[offset].__key__, (
+                        f"{sample} != {initial_samples[offset]}"
+                    )
+                    assert sample.__restore_key__ == initial_samples[offset].__restore_key__, (
+                        f"{sample} != {initial_samples[offset]}"
+                    )
+                except Exception as e:
+                    print(
+                        "samples:"
+                        + f"\n [@{offset + skip_initial}] {sample.text}"
+                        + "".join(
+                            f"\n [@{idx}] {sample.text}"
+                            for idx, sample in zip(
+                                range(skip_initial + offset + 1, skip_initial + offset + 6),
+                                second_loader,
+                            )
+                        )
+                    )
+                    raise ValueError(f"Failed to iterate @{offset + skip_initial} samples") from e
+
+                # Restore state in a new loader
+                ref_loader = get_savable_loader(
+                    get_train_dataset(
+                        self.nested_mds_path,
+                        worker_config=wc,
+                        batch_size=1,
+                        shuffle_buffer_size=None,
+                        max_samples_per_sequence=None,
+                    ),
+                    checkpoint_every_sec=0,
+                    checkpoint_every_min_n_samples=0,
+                )
+                ref_loader.restore_state_rank(state_offset)
+
+                # Get 1 sample from the restored loader
+                next_loader_samples = [sample for _, sample in zip(range(6), ref_loader)]
+                assert len(next_loader_samples) == 6
+                next_loader_sample = next_loader_samples[0]
+                print(
+                    "next_loader_samples:"
+                    + f"\n [@{offset + skip_initial}] {sample.text}"
+                    + "".join(
+                        f"\n [@{idx}] {sample}"
+                        for idx, sample in zip(
+                            range(skip_initial + offset, skip_initial + offset + 6),
+                            next_loader_samples,
+                        )
+                    )
+                )
+                assert next_loader_sample.text == sample.text, f"{next_loader_sample} != {sample}"
+                assert next_loader_sample.__key__ == sample.__key__, (
+                    f"{next_loader_sample} != {sample}"
+                )
+                assert next_loader_sample.__restore_key__ == sample.__restore_key__, (
+                    f"{next_loader_sample} != {sample}"
+                )
+            except Exception as e:
+                raise ValueError(f"Failed to iterate @{skip_initial}+{offset} samples") from e
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_metadataset_fewsamp.py
+++ b/tests/test_metadataset_fewsamp.py
@@ -24,6 +24,13 @@ from megatron.energon import (
 )
 from megatron.energon.flavors.webdataset import MAIN_FOLDER_NAME
 
+# Speed up tests significantly by reducing the torch status check interval for broken worker shutdown
+try:
+    torch.utils.data._utils.worker.MP_STATUS_CHECK_INTERVAL = 0.1
+    torch.utils.data._utils.MP_STATUS_CHECK_INTERVAL = 0.1
+except AttributeError:
+    pass
+
 
 def _norng_state(state):
     if isinstance(state, bytes):

--- a/tests/test_metadataset_v2.py
+++ b/tests/test_metadataset_v2.py
@@ -35,6 +35,13 @@ from megatron.energon.metadataset.loader_interface import DatasetBlendMode
 from megatron.energon.task_encoder.base import DefaultTaskEncoder
 from megatron.energon.wrappers.watchdog_dataset import WatchdogDataset
 
+# Speed up tests significantly by reducing the torch status check interval for broken worker shutdown
+try:
+    torch.utils.data._utils.worker.MP_STATUS_CHECK_INTERVAL = 0.1
+    torch.utils.data._utils.MP_STATUS_CHECK_INTERVAL = 0.1
+except AttributeError:
+    pass
+
 
 def _norng_state(state):
     if isinstance(state, bytes):


### PR DESCRIPTION
Fix: Restoring had the worker index wrong and saving a just restored state, when none or not all workers have iterated yet.

Added test for this.

Smaller fixes:
* Worker shutdown in tests is faster.
* print rng state more compact
