### PR TITLE
Fix sharder for too few samples for a worker

### DIFF
--- a/src/megatron/energon/flavors/webdataset/sharder.py
+++ b/src/megatron/energon/flavors/webdataset/sharder.py
@@ -61,9 +61,7 @@ class Sharder:
         for start_offset, end_offset in zip(offsets, offsets[1:]):
             # Find shard idx for end
             end_index = start_index
-            while True:
-                if end_offset <= shard_cumsums[end_index + 1]:
-                    break
+            while end_index + 1 < len(shard_cumsums) and end_offset > shard_cumsums[end_index + 1]:
                 end_index += 1
             if start_index == end_index:
                 yield (


### PR DESCRIPTION
Fixes the following case: A composed dataset does have a small subdataset, which does not provide a sample for every worker. In that case, it crashed with:

```
  File "megatron/energon/flavors/webdataset/base_webdataset.py", line 126, in build
    workers_sample_slice_offsets = self.shard_workers(
                                   ^^^^^^^^^^^^^^^^^^^
  File "megatron/energon/flavors/webdataset/sharder.py", line 308, in shard_workers
    return tuple(
           ^^^^^^
  File "megatron/energon/flavors/webdataset/sharder.py", line 308, in <genexpr>
    return tuple(
                ^
  File "megatron/energon/flavors/webdataset/sharder.py", line 65, in _split_shards
    if end_offset <= shard_cumsums[end_index + 1]:
                     ~~~~~~~~~~~~~^^^^^^^^^^^^^^^
IndexError: index 2 is out of bounds for axis 0 with size 2
```