### PR TITLE
Use Per-Frame Durations instead of Average 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ av_decode = [
   "sortedcontainers>=2.4.0",
   "filetype>=1.2.0",
   "ebmlite>=3.3.1",
-  "av>=13.0.0",
+  "av>=14.4.0",
 ]
 # If using guess_content=True for decoding
 guess_content = [

--- a/src/megatron/energon/av/av_decoder.py
+++ b/src/megatron/energon/av/av_decoder.py
@@ -106,7 +106,6 @@ class AVDecoder:
             assert average_rate, "Video stream has no FPS."
 
             time_base: Fraction = video_stream.time_base  # Seconds per PTS unit
-            average_frame_duration: int = int(1 / average_rate / time_base)  # PTS units per frame
 
             if video_clip_ranges is not None:
                 # Convert video_clip_ranges to seeker unit
@@ -183,11 +182,10 @@ class AVDecoder:
                     # Container uses time, the target frame might not correspond exactly to any metadata but the desired timestamp should
                     # fall within a frames display period
                     if self.seeker.unit == "pts":
-                        if start_frame_index <= frame.pts + average_frame_duration:
+                        if start_frame_index <= (frame.pts + frame.duration):
                             take_frame = True
-                        if (
-                            end_frame_index is not None
-                            and end_frame_index <= frame.pts + average_frame_duration
+                        if end_frame_index is not None and end_frame_index <= (
+                            frame.pts + frame.duration
                         ):
                             last_frame = True
 
@@ -206,9 +204,7 @@ class AVDecoder:
                         if clip_timestamp_start is None:
                             clip_timestamp_start = float(frame.pts * frame.time_base)
 
-                        clip_timestamp_end = float(
-                            (frame.pts + average_frame_duration) * frame.time_base
-                        )
+                        clip_timestamp_end = float((frame.pts + frame.duration) * frame.time_base)
 
                     previous_frame_index += 1
 
@@ -314,7 +310,7 @@ class AVDecoder:
                 for frame in input_container.decode(audio=0):
                     assert frame.pts is not None, "Audio frame has no PTS timestamp"
                     cur_frame_time = float(frame.pts * frame.time_base)
-                    cur_frame_duration = float(frame.samples / audio_sample_rate)
+                    cur_frame_duration = float(frame.duration * frame.time_base)
 
                     if cur_frame_time < start_time:
                         # Skip frames before the start time

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ transforms = [
 
 [package.metadata]
 requires-dist = [
-    { name = "av", marker = "extra == 'av-decode'", specifier = ">=13.0.0" },
+    { name = "av", marker = "extra == 'av-decode'", specifier = ">=14.4.0" },
     { name = "bitstring", marker = "extra == 'av-decode'", specifier = ">=4.2.3" },
     { name = "braceexpand" },
     { name = "click" },


### PR DESCRIPTION
In https://github.com/PyAV-Org/PyAV/pull/1880 I added support for the ffmpeg `duration` field on frames (it was previously only present in packets). That PR was shipped in PyAV 14.4.0 and this PR updates energon to use this field instead of a computed average duration. 

Since variable frame-rate videos can have frames with differing durations this PR makes our decode loop more accurate.
