### PR TITLE
Implement caching out an object to a file

### DIFF
--- a/src/megatron/energon/cache/base.py
+++ b/src/megatron/energon/cache/base.py
@@ -126,6 +126,13 @@ class CachePool(ABC):
         ...
 
     @abstractmethod
+    def to_cache(self, data: T, name: str) -> Lazy[T]:
+        """
+        Move the data to the cache and return a lazy to fetch it later.
+        """
+        ...
+
+    @abstractmethod
     def close(self) -> None:
         """
         Close the cache pool.

--- a/src/megatron/energon/cache/base.py
+++ b/src/megatron/energon/cache/base.py
@@ -129,6 +129,7 @@ class CachePool(ABC):
     def to_cache(self, data: T, name: str) -> Lazy[T]:
         """
         Move the data to the cache and return a lazy to fetch it later.
+        The name is used for debugging the data in the cache.
         """
         ...
 

--- a/src/megatron/energon/cache/file_cache_pool.py
+++ b/src/megatron/energon/cache/file_cache_pool.py
@@ -73,8 +73,10 @@ class CacheFileLazy(Lazy[T]):
     Represents a reference to a cached object without deduplication.
     """
 
+    # The path to the file that contains the cached pickled object.
     cache_path: Path | None
 
+    # If get() was called, this will be the data (uncached).
     _data: Optional[T] = None
 
     def get(self, sample: Any = None) -> T:
@@ -90,7 +92,7 @@ class CacheFileLazy(Lazy[T]):
 
     def __del__(self):
         if self.cache_path is not None:
-            self.cache_path.unlink()
+            self.cache_path.unlink(missing_ok=True)
             self.cache_path = None
 
     def __hash__(self) -> int:

--- a/src/megatron/energon/cache/no_cache.py
+++ b/src/megatron/energon/cache/no_cache.py
@@ -3,7 +3,7 @@
 
 from typing import Any, Optional, TypeVar
 
-from megatron.energon.cache.base import CachePool, FileStore, Lazy
+from megatron.energon.cache.base import CachePool, FileStore, Lazy, MockLazy
 from megatron.energon.edataclass import edataclass
 from megatron.energon.source_info import SourceInfo, add_source_info
 
@@ -46,6 +46,9 @@ class NoCachePool(CachePool):
 
     def get_lazy(self, ds: FileStore, fname: str) -> DirectLazy:
         return DirectLazy(ds=ds, fname=fname, pool=self)
+
+    def to_cache(self, data: T, name: str) -> DirectLazy:
+        return MockLazy(fname=name, get_fn=lambda _: data)
 
     def close(self) -> None:
         pass


### PR DESCRIPTION
* Implement `cache.to_cache` to move a pickleable object to the cache for later usage
* Tests are missing yet