### PR TITLE
Make AVDecoder picklable also for videos

### DIFF
--- a/src/megatron/energon/av/fastseek/containers/mpeg.py
+++ b/src/megatron/energon/av/fastseek/containers/mpeg.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: BSD-3-Clause
-from collections import defaultdict
 from itertools import accumulate
 from typing import Any, Generator
 
@@ -184,8 +183,8 @@ def parse_atoms(file: BitsType) -> Generator[Atom, None, None]:
 def parse_mpeg(file: BitsType) -> dict[int, SortedList]:
     sync_samples = {}
     decode_timestamps = {}
-    presentation_time_offsets = defaultdict(lambda: defaultdict(lambda: 0))
-    start_offsets = defaultdict(lambda: 0)
+    presentation_time_offsets = {}
+    start_offsets = {}
     current_track = -1
     for a in parse_atoms(file):
         if a.name == "tkhd":
@@ -223,14 +222,16 @@ def parse_mpeg(file: BitsType) -> dict[int, SortedList]:
             # TODO there can be more than one of these, figure out how to handle it
             a: ELST
             start_offsets[current_track] = -a.edit_list_table[0]["media_time"]
-    keyframes = defaultdict(lambda: SortedList())
+    keyframes = {}
     try:
         for track_id in sync_samples.keys():
+            if track_id not in keyframes:
+                keyframes[track_id] = SortedList()
             for keyframe_number in sync_samples[track_id]:
                 pts = (
                     decode_timestamps[track_id][keyframe_number]
-                    + start_offsets[track_id]
-                    + presentation_time_offsets[track_id][keyframe_number]
+                    + start_offsets.get(track_id, 0)
+                    + presentation_time_offsets.get(track_id, [])[keyframe_number]
                 )
                 keyframes[track_id].add(KeyframeInfo(keyframe_number, pts))
     except (KeyError, IndexError) as e:

--- a/tests/test_av_decoder.py
+++ b/tests/test_av_decoder.py
@@ -6,6 +6,7 @@
 import io
 import logging
 import os
+import pickle
 import sys
 import time
 import unittest
@@ -217,6 +218,37 @@ class TestVideoDecode(unittest.TestCase):
             assert tensors_close(audio_clip, audio_clips[0], tolerance=0.01), (
                 "All audio clips are not the same"
             )
+
+    def test_pickle_decoder(self):
+        """Test AVDecoder on a video file can be pickled and unpickled."""
+        av_decoder = AVDecoder(io.BytesIO(Path("tests/data/sync_test.mp4").read_bytes()))
+        
+        # Get metadata from original decoder
+        original_metadata = av_decoder.get_metadata()
+        
+        # Pickle the decoder
+        pickled_data = pickle.dumps(av_decoder)
+        
+        # Unpickle the decoder
+        unpickled_decoder = pickle.loads(pickled_data)
+        
+        # Verify metadata matches
+        unpickled_metadata = unpickled_decoder.get_metadata()
+        assert unpickled_metadata == original_metadata, (
+            f"Unpickled metadata {unpickled_metadata} does not match original {original_metadata}"
+        )
+        
+        # Verify we can still decode frames from the unpickled decoder
+        video_tensor = get_single_frames_uniform(
+            av_decoder=unpickled_decoder,
+            num_frames=16,
+            video_out_frame_size=(64, 64),
+        )
+        
+        # Check that we got the expected shape
+        assert video_tensor.shape == (16, 3, 64, 64), (
+            f"Expected shape (16, 3, 64, 64), got {video_tensor.shape}"
+        )
 
 
 def load_audio_to_tensor(audio_path: str) -> torch.Tensor:


### PR DESCRIPTION
Previously, trying to pickle an `AVDecoder` object (for example by `to_cache`) that was created on an mpeg file,
would result in an error `AttributeError: Can't pickle local object 'parse_mpeg.<locals>.<lambda>'`

This PR fixes it and tests this case.