### PR TITLE
Implement fixing permissions of written local files during prepare / media-prepare

### DIFF
--- a/src/megatron/energon/epathlib/epath.py
+++ b/src/megatron/energon/epathlib/epath.py
@@ -197,6 +197,11 @@ class EPath:
     def is_local(self) -> bool:
         return self.profile == DEFAULT_PROFILE_NAME
 
+    def local_path(self) -> PathlibPath:
+        if not self.is_local():
+            raise ValueError(f"Path {self} is not local")
+        return PathlibPath(self._internal_str_path)
+
     def is_dir(self) -> bool:
         try:
             return self.fs.info(self._internal_str_path).type == "directory"

--- a/src/megatron/energon/flavors/jsonl/ijsonl.py
+++ b/src/megatron/energon/flavors/jsonl/ijsonl.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import struct
-from pathlib import Path
 from typing import BinaryIO, Dict, Generator, Optional, Tuple, Union
 
 from megatron.energon.edataclass import edataclass
@@ -91,8 +90,8 @@ class IJsonlIndexWriter:
                 # To ensure the final file permissions match the jsonl path in the local setting.
                 # Copy permissions from jsonl_path to final_name, making sure the owner can read and write.
                 try:
-                    Path(str(self.final_name)).chmod(
-                        Path(str(self.jsonl_path)).stat().st_mode | 0o600
+                    self.final_name.local_path().chmod(
+                        self.jsonl_path.local_path().stat().st_mode | 0o600
                     )
                 except OSError:
                     # Just ignore the error, it's not a big deal.

--- a/src/megatron/energon/flavors/jsonl/ijsonl.py
+++ b/src/megatron/energon/flavors/jsonl/ijsonl.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import struct
+from pathlib import Path
 from typing import BinaryIO, Dict, Generator, Optional, Tuple, Union
 
 from megatron.energon.edataclass import edataclass
@@ -74,6 +75,7 @@ class IJsonlIndexReader:
 
 class IJsonlIndexWriter:
     def __init__(self, jsonl_path: EPath):
+        self.jsonl_path = jsonl_path
         self.final_name = jsonl_path.with_suffix(IJSONL_SUFFIX)
         self.tmp_name = jsonl_path.with_suffix(IJSONL_SUFFIX + ".tmp")
         self.ijsonl = self.tmp_name.open("wb")
@@ -85,6 +87,16 @@ class IJsonlIndexWriter:
         self.ijsonl.close()
         if finalize:
             self.tmp_name.move(self.final_name)
+            if self.jsonl_path.is_local():
+                # To ensure the final file permissions match the jsonl path in the local setting.
+                # Copy permissions from jsonl_path to final_name, making sure the owner can read and write.
+                try:
+                    Path(str(self.final_name)).chmod(
+                        Path(str(self.jsonl_path)).stat().st_mode | 0o600
+                    )
+                except OSError:
+                    # Just ignore the error, it's not a big deal.
+                    pass
         else:
             self.tmp_name.unlink()
 

--- a/src/megatron/energon/flavors/webdataset/indexing.py
+++ b/src/megatron/energon/flavors/webdataset/indexing.py
@@ -3,7 +3,6 @@
 
 import sqlite3
 import struct
-from pathlib import Path
 from typing import BinaryIO, Generator, List, Optional, Tuple, Union
 
 from numpy import int8
@@ -64,13 +63,10 @@ class SqliteIndexWriter:
         self.reset_tables = reset_tables
 
         # Initialize SQLite connection
-        path = str(self.sqlite_path)
         # Only supporting local file system, because sqlite does not support remote file systems.
         # TODO: Implement remote file systems. Maybe create locally in tmp then upload?
-        assert path.startswith("/"), (
-            f"SQLite path must be absolute local file system path: {self.sqlite_path}"
-        )
-        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        path = self.sqlite_path.local_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
         self.db = sqlite3.connect(path)
         self.db.execute("PRAGMA busy_timeout = 5000;")  # wait up to 5000ms when locked
 
@@ -328,12 +324,8 @@ class SqliteIndexReader:
         self.sqlite_path = ensure_local_copy(sqlite_path)
 
         # Initialize SQLite connection
-        path = str(self.sqlite_path)
         # Only supporting local file system, because sqlite does not support remote file systems
-        assert path.startswith("/"), (
-            f"SQLite path must be absolute local file system path: {self.sqlite_path}"
-        )
-
+        path = self.sqlite_path.local_path()
         path = f"file:{path}?mode=ro&immutable=1"
 
         self.db = ThreadLocalSqlite(path, is_uri=True)

--- a/src/megatron/energon/flavors/webdataset/itar.py
+++ b/src/megatron/energon/flavors/webdataset/itar.py
@@ -4,6 +4,7 @@
 import contextlib
 import struct
 import tarfile
+from pathlib import Path
 from types import TracebackType
 from typing import BinaryIO, Dict, Generator, Optional, Tuple, Type, Union
 
@@ -85,6 +86,7 @@ class TarIndexReader:
 
 class TarIndexWriter:
     def __init__(self, tar_path: EPath):
+        self.tar_path = tar_path
         self.final_name = tar_path.with_suffix(ITAR_SUFFIX)
         self.tmp_name = tar_path.with_suffix(ITAR_SUFFIX + ".tmp")
         self.itar = self.tmp_name.open("wb")
@@ -96,6 +98,16 @@ class TarIndexWriter:
         self.itar.close()
         if finalize:
             self.tmp_name.move(self.final_name)
+            if self.tar_path.is_local():
+                # To ensure the final file permissions match the tar path in the local setting.
+                # Copy permissions from tar_path to final_name, making sure the owner can read and write.
+                try:
+                    Path(str(self.final_name)).chmod(
+                        Path(str(self.tar_path)).stat().st_mode | 0o600
+                    )
+                except OSError:
+                    # Just ignore the error, it's not a big deal.
+                    pass
         else:
             self.tmp_name.unlink()
 

--- a/src/megatron/energon/flavors/webdataset/itar.py
+++ b/src/megatron/energon/flavors/webdataset/itar.py
@@ -4,7 +4,6 @@
 import contextlib
 import struct
 import tarfile
-from pathlib import Path
 from types import TracebackType
 from typing import BinaryIO, Dict, Generator, Optional, Tuple, Type, Union
 
@@ -102,8 +101,8 @@ class TarIndexWriter:
                 # To ensure the final file permissions match the tar path in the local setting.
                 # Copy permissions from tar_path to final_name, making sure the owner can read and write.
                 try:
-                    Path(str(self.final_name)).chmod(
-                        Path(str(self.tar_path)).stat().st_mode | 0o600
+                    self.final_name.local_path().chmod(
+                        self.tar_path.local_path().stat().st_mode | 0o600
                     )
                 except OSError:
                     # Just ignore the error, it's not a big deal.

--- a/src/megatron/energon/flavors/webdataset/prepare.py
+++ b/src/megatron/energon/flavors/webdataset/prepare.py
@@ -504,6 +504,21 @@ class WebdatasetPreparator:
 
         (parent_path / MAIN_FOLDER_NAME).mkdir(exist_ok=True)
 
+        if parent_path.is_local():
+            # Copy permissions from parent_path to json_info_config and yaml_info_config, making sure the owner can read and write.
+            # Copy permissions from the first shard
+            try:
+                dir_perms = Path(str(parent_path)).stat().st_mode | 0o700
+                file_perms = Path(str(parent_path / paths[0])).stat().st_mode | 0o600
+                Path(str(parent_path / MAIN_FOLDER_NAME)).chmod(dir_perms)
+                fix_local_permissions = True
+            except OSError:
+                # Just ignore the error, it's not a big deal.
+                pass
+                fix_local_permissions = False
+        else:
+            fix_local_permissions = False
+
         if fix_duplicates:
             try:
                 from megatron.energon.flavors.webdataset.tar_patcher import TarPatcher
@@ -573,10 +588,26 @@ class WebdatasetPreparator:
 
             sys.exit(1)
 
+        # Fix permissions if needed
+        if fix_local_permissions:
+            try:
+                Path(str(parent_path / MAIN_FOLDER_NAME / INDEX_SQLITE_FILENAME)).chmod(file_perms)
+            except OSError:
+                pass
+
         if had_update:
             logger.info("Regenerating dataset UUID...")
             with (parent_path / MAIN_FOLDER_NAME / INDEX_UUID_FILENAME).open("w") as f:
                 f.write(str(uuid.uuid4()))
+
+            # Fix permissions if needed
+            if fix_local_permissions:
+                try:
+                    Path(str(parent_path / MAIN_FOLDER_NAME / INDEX_UUID_FILENAME)).chmod(
+                        file_perms
+                    )
+                except OSError:
+                    pass
 
         json_info_config = parent_path / MAIN_FOLDER_NAME / INFO_JSON_FILENAME
         yaml_info_config = parent_path / MAIN_FOLDER_NAME / INFO_YAML_FILENAME
@@ -586,6 +617,12 @@ class WebdatasetPreparator:
                 # Convert legacy .info.yaml to .info.json
                 with json_info_config.open("w") as f:
                     json.dump(load_yaml(yaml_info_config.read_bytes()), f, indent=2)
+
+                if fix_local_permissions:
+                    try:
+                        Path(str(json_info_config)).chmod(file_perms)
+                    except OSError:
+                        pass
 
             return found_parts
 
@@ -609,6 +646,13 @@ class WebdatasetPreparator:
 
         with json_info_config.open("w") as wf:
             json.dump(to_json_object(info), wf, indent=2)
+
+        # Fix permissions if needed
+        if fix_local_permissions:
+            try:
+                Path(str(json_info_config)).chmod(file_perms)
+            except OSError:
+                pass
 
         if yaml_info_config.is_file():
             # If a .info.yaml existed previously, let's also update it
@@ -665,6 +709,13 @@ class WebdatasetPreparator:
                 json.dump(to_json_object(splits_config), wf, indent=2)
             else:
                 raise ValueError(f"Invalid split config extension: {split_config}")
+
+        # Fix permissions if needed
+        if fix_local_permissions:
+            try:
+                Path(str(parent_path / MAIN_FOLDER_NAME / split_config)).chmod(file_perms)
+            except OSError:
+                pass
 
         return found_parts
 

--- a/src/megatron/energon/flavors/webdataset/prepare.py
+++ b/src/megatron/energon/flavors/webdataset/prepare.py
@@ -508,9 +508,9 @@ class WebdatasetPreparator:
             # Copy permissions from parent_path to json_info_config and yaml_info_config, making sure the owner can read and write.
             # Copy permissions from the first shard
             try:
-                dir_perms = Path(str(parent_path)).stat().st_mode | 0o700
-                file_perms = Path(str(parent_path / paths[0])).stat().st_mode | 0o600
-                Path(str(parent_path / MAIN_FOLDER_NAME)).chmod(dir_perms)
+                dir_perms = parent_path.local_path().stat().st_mode | 0o700
+                file_perms = (parent_path / paths[0]).local_path().stat().st_mode | 0o600
+                (parent_path / MAIN_FOLDER_NAME).local_path().chmod(dir_perms)
                 fix_local_permissions = True
             except OSError:
                 # Just ignore the error, it's not a big deal.
@@ -603,7 +603,7 @@ class WebdatasetPreparator:
             # Fix permissions if needed
             if fix_local_permissions:
                 try:
-                    Path(str(parent_path / MAIN_FOLDER_NAME / INDEX_UUID_FILENAME)).chmod(
+                    (parent_path / MAIN_FOLDER_NAME / INDEX_UUID_FILENAME).local_path().chmod(
                         file_perms
                     )
                 except OSError:
@@ -620,7 +620,7 @@ class WebdatasetPreparator:
 
                 if fix_local_permissions:
                     try:
-                        Path(str(json_info_config)).chmod(file_perms)
+                        json_info_config.local_path().chmod(file_perms)
                     except OSError:
                         pass
 
@@ -650,7 +650,7 @@ class WebdatasetPreparator:
         # Fix permissions if needed
         if fix_local_permissions:
             try:
-                Path(str(json_info_config)).chmod(file_perms)
+                json_info_config.local_path().chmod(file_perms)
             except OSError:
                 pass
 
@@ -713,7 +713,7 @@ class WebdatasetPreparator:
         # Fix permissions if needed
         if fix_local_permissions:
             try:
-                Path(str(parent_path / MAIN_FOLDER_NAME / split_config)).chmod(file_perms)
+                (parent_path / MAIN_FOLDER_NAME / split_config).local_path().chmod(file_perms)
             except OSError:
                 pass
 

--- a/src/megatron/energon/media/filesystem_prepare.py
+++ b/src/megatron/energon/media/filesystem_prepare.py
@@ -94,6 +94,14 @@ def prepare_filesystem_dataset(
 
     pool.process()
 
+    try:
+        # Copy group permissions from the parent dir
+        meta_dir.chmod((root.stat().st_mode | 0o700))
+        # Just read/write, no execute
+        Path(str(sqlite_path)).chmod((root.stat().st_mode | 0o600) & 0o666)
+    except OSError:
+        pass
+
     return aggregator.media_metadata_written
 
 

--- a/src/megatron/energon/media/filesystem_prepare.py
+++ b/src/megatron/energon/media/filesystem_prepare.py
@@ -41,11 +41,7 @@ def prepare_filesystem_dataset(
 
     # Only supporting local file system, because sqlite does not support remote file systems.
     # TODO: Implement remote file systems. Maybe create locally in tmp then upload?
-    assert str(root_path).startswith("/"), (
-        f"SQLite path must be absolute local file system path: {root_path}"
-    )
-
-    root = Path(str(root_path))
+    root = root_path.local_path()
     assert root.is_dir(), f"Expected directory for filesystem dataset, got {root}"
     assert root.is_absolute(), f"Filesystem dataset path must be absolute: {root}"
 
@@ -98,7 +94,7 @@ def prepare_filesystem_dataset(
         # Copy group permissions from the parent dir
         meta_dir.chmod((root.stat().st_mode | 0o700))
         # Just read/write, no execute
-        Path(str(sqlite_path)).chmod((root.stat().st_mode | 0o600) & 0o666)
+        sqlite_path.local_path().chmod((root.stat().st_mode | 0o600) & 0o666)
     except OSError:
         pass
 


### PR DESCRIPTION
During:
energon prepare:
* Set `.nv-meta` folder permissions to the same as the parent folder
* Fix all `.nv-meta` files permissions, set file permissions to the same as the first shard
* For `.tar.idx` files, copy permissions from `.tar` files

energon prepare .jsonl:
* For `.jsonl.idx` files, copy permissions from `.jsonl` file

energon media-prepare:
* Use permissions from parent folder for `.nv-meta` folder, and also for the sqlite index within (`& 0o666`).