### PR TITLE
Fixing duplicate SkipSample class

### DIFF
--- a/src/megatron/energon/__init__.py
+++ b/src/megatron/energon/__init__.py
@@ -24,7 +24,7 @@ from megatron.energon.cache import (
     SystemFileStore,
 )
 from megatron.energon.edataclass import edataclass
-from megatron.energon.errors import log_exception, reraise_exception
+from megatron.energon.errors import SkipSample, log_exception, reraise_exception
 from megatron.energon.flavors import (
     BaseCoreDatasetFactory,
     BaseWebdatasetFactory,
@@ -107,7 +107,6 @@ from megatron.energon.wrappers import (
     PackingDataset,
     RepeatDataset,
     ShuffleBufferDataset,
-    SkipSample,
     concat_pad,
     generic_concat,
     homogeneous_concat_mix,

--- a/src/megatron/energon/wrappers/skip.py
+++ b/src/megatron/energon/wrappers/skip.py
@@ -1,6 +1,17 @@
 # Copyright (c) 2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import warnings
+
 
 class SkipSample(Exception):
-    """Exception to raise in the map_fn to skip a sample."""
+    """DEPRECATED, USE `megatron.energon.SkipSample` INSTEAD.
+    Exception to raise in the map_fn to skip a sample."""
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "SkipSample is deprecated and will be removed in a future version. Use megatron.energon.SkipSample instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/megatron/energon/wrappers/skip.py
+++ b/src/megatron/energon/wrappers/skip.py
@@ -1,17 +1,17 @@
 # Copyright (c) 2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: BSD-3-Clause
 
-import warnings
+from megatron.energon.deprecation import warn_deprecated
+from megatron.energon.errors import SkipSample as _SkipSample
 
 
-class SkipSample(Exception):
-    """DEPRECATED, USE `megatron.energon.SkipSample` INSTEAD.
-    Exception to raise in the map_fn to skip a sample."""
+class SkipSample(_SkipSample):
+    """Deprecated alias for :class:`megatron.energon.SkipSample`."""
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "SkipSample is deprecated and will be removed in a future version. Use megatron.energon.SkipSample instead.",
-            DeprecationWarning,
+        warn_deprecated(
+            "megatron.energon.wrappers.SkipSample is deprecated and will be removed in a future "
+            "version. Use megatron.energon.SkipSample instead.",
             stacklevel=2,
         )
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
The `SkipSample` class is defined two times:
- In `megatron.energon.errors`: [link](https://github.com/NVIDIA/Megatron-Energon/blob/d84075adb2d787d37ad8f9b958fde5445c002188/src/megatron/energon/errors.py#L13)
- In`megatron.energon.wrappers`: [link](https://github.com/NVIDIA/Megatron-Energon/blob/d84075adb2d787d37ad8f9b958fde5445c002188/src/megatron/energon/wrappers/skip.py#L5)

Both definitions are distinct error classes, although named the same. However, only the `megatron.energon.errors` definition is caught by megatron-energon [here](https://github.com/NVIDIA/Megatron-Energon/blob/d84075adb2d787d37ad8f9b958fde5445c002188/src/megatron/energon/errors.py#L115) and [here](https://github.com/NVIDIA/Megatron-Energon/blob/d84075adb2d787d37ad8f9b958fde5445c002188/src/megatron/energon/errors.py#L161).

The main `megatron.energon` init file is also importing the invalid `megatron.energon.wrappers` definition of the `SkipSample` class, leading to crashes in the run log when importing from the main package definition.

This PR deprecates the invalid duplicate and points the `megatron.energon` init file to the correct subpackage definition of the `SkipSample` class.