### PR TITLE
Batch WebDataset index writes during prepare_dataset

### DIFF
--- a/src/megatron/energon/flavors/webdataset/aggregator_pool.py
+++ b/src/megatron/energon/flavors/webdataset/aggregator_pool.py
@@ -25,9 +25,9 @@ class BaseAggregator(ABC, Generic[T_aggregation_data, T_result]):
         pass
 
     @abstractmethod
-    def on_item(self, item: T_aggregation_data, aggregator_pool: AggregatorPool) -> None:
+    def on_item(self, items: List[T_aggregation_data], aggregator_pool: AggregatorPool) -> None:
         """
-        Called for each item produced by the workers.
+        Called for each batch of items produced by the workers.
         """
         ...
 
@@ -58,25 +58,33 @@ class AggregatorPool(Generic[T_input_data, T_aggregation_data, T_result]):
     num_workers: int
     user_produce_data: Callable[[T_input_data], Iterable[Any]]
     aggregator: BaseAggregator[T_aggregation_data, T_result]
+    batch_size: int
 
     task_queue: multiprocessing.Queue[Optional[T_input_data]]
-    result_queue: multiprocessing.Queue[Optional[T_aggregation_data]]
+    result_queue: multiprocessing.Queue[Optional[List[T_aggregation_data]]]
 
     def __init__(
         self,
         num_workers: int,
         user_produce_data: Callable[[T_input_data], Iterable[Any]],
         aggregator: BaseAggregator[T_aggregation_data, T_result],
+        *,
+        batch_size: int = 1,
     ) -> None:
         """
         Args:
             num_workers: Number of worker processes.
             user_produce_data: Function that takes a task and yields items (the "large" data stream).
             aggregator: An instance of a user-defined class for handling aggregator logic.
+            batch_size: Maximum number of produced items to send to the aggregator at once.
         """
+        if batch_size <= 0:
+            raise ValueError(f"batch_size must be positive, got {batch_size}")
+
         self.num_workers = num_workers
         self.user_produce_data = user_produce_data
         self.aggregator = aggregator
+        self.batch_size = batch_size
 
         # Queues for tasks and results
         self.task_queue = multiprocessing.Queue()
@@ -90,15 +98,26 @@ class AggregatorPool(Generic[T_input_data, T_aggregation_data, T_result]):
 
     def _worker(self, worker_id: int) -> None:
         """Function that runs inside each worker process."""
+        batch: List[T_aggregation_data] = []
+
         while True:
             task = self.task_queue.get()
             if task is None:
                 # No more tasks, signal aggregator that this worker is done
+                if batch:
+                    self.result_queue.put(batch)
                 break
 
             # Produce data in a streaming fashion
             for item in self.user_produce_data(task):
-                self.result_queue.put(item)
+                batch.append(item)
+                if len(batch) >= self.batch_size:
+                    self.result_queue.put(batch)
+                    batch = []
+
+            if batch:
+                self.result_queue.put(batch)
+                batch = []
 
         # After finishing all tasks, send a sentinel to the aggregator
         self.result_queue.put(None)
@@ -108,7 +127,7 @@ class AggregatorPool(Generic[T_input_data, T_aggregation_data, T_result]):
         Function that runs in the aggregator process.
         Keeps reading items from result_queue.
         - If an item is None, that means a worker finished all of its tasks.
-        - Otherwise, call aggregator.on_item(...) with that item.
+        - Otherwise, call aggregator.on_item(...) with that batch.
         """
         # Let the aggregator do any initialization it needs
         self.aggregator.on_start(self)
@@ -116,13 +135,13 @@ class AggregatorPool(Generic[T_input_data, T_aggregation_data, T_result]):
         finished_workers = 0
 
         while finished_workers < self.num_workers:
-            item = self.result_queue.get()
-            if item is None:
+            item_batch = self.result_queue.get()
+            if item_batch is None:
                 # A worker has finished all of its tasks
                 finished_workers += 1
             else:
                 # Process the item in the aggregator
-                self.aggregator.on_item(item, self)
+                self.aggregator.on_item(item_batch, self)
 
         # All workers done, aggregator can finalize
         self.aggregator.on_finish(self)

--- a/src/megatron/energon/flavors/webdataset/config.py
+++ b/src/megatron/energon/flavors/webdataset/config.py
@@ -7,6 +7,7 @@ split_name_re = re.compile(r"^((?:.*/|)[^.]+)[.]([^/]*)$")
 skip_meta_re = re.compile(r"__[^/]*__($|/)")
 MAIN_FOLDER_NAME = ".nv-meta"
 JOIN_INDEX_FILENAME = "join_index.bin"
+INDEX_BATCH_SIZE = 4096
 INDEX_SQLITE_FILENAME = "index.sqlite"
 INDEX_UUID_FILENAME = "index.uuid"
 INFO_JSON_FILENAME = ".info.json"

--- a/src/megatron/energon/flavors/webdataset/indexing.py
+++ b/src/megatron/energon/flavors/webdataset/indexing.py
@@ -137,38 +137,6 @@ class SqliteIndexWriter:
                 """
             )
 
-    def append_sample(
-        self,
-        tar_file_id: int8,
-        sample_key: str,
-        sample_index: int,
-        byte_offset: Optional[int],
-        byte_size: Optional[int],
-    ):
-        """
-        Adds a new sample row to the samples table.
-
-        Args:
-            tar_file_id: The index of the tar file in the reader.
-            sample_key: The key of the sample.
-            sample_index: The index of the sample in the tar file.
-            byte_offset: The byte offset of the sample in the tar file.
-            byte_size: The size of the sample in the tar file.
-        """
-
-        assert self.db is not None, "Database is closed"
-
-        try:
-            self.db.execute(
-                """
-                INSERT INTO samples (tar_file_id, sample_key, sample_index, byte_offset, byte_size)
-                VALUES (?, ?, ?, ?, ?)
-                """,
-                (tar_file_id, sample_key, sample_index, byte_offset, byte_size),
-            )
-        except sqlite3.IntegrityError as exc:
-            raise DuplicateSampleKeyError(sample_key) from exc
-
     def append_samples(
         self,
         rows: Sequence["IndexSample"],
@@ -207,26 +175,6 @@ class SqliteIndexWriter:
             self.db.execute(f"RELEASE SAVEPOINT {savepoint_name}")
             raise DuplicateSampleKeyError(self._find_duplicate_sample_key(rows)) from exc
 
-    def append_part(
-        self,
-        tar_file_id: int8,
-        sample_index: int,
-        part_name: str,
-        content_byte_offset: int,
-        content_byte_size: int,
-    ):
-        """Adds a new part row to the samples table."""
-
-        assert self.db is not None, "Database is closed"
-
-        self.db.execute(
-            """
-            INSERT INTO sample_parts (tar_file_id, sample_index, part_name, content_byte_offset, content_byte_size)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            (tar_file_id, sample_index, part_name, content_byte_offset, content_byte_size),
-        )
-
     def append_parts(
         self,
         rows: Sequence["IndexSamplePart"],
@@ -253,26 +201,6 @@ class SqliteIndexWriter:
                 )
                 for row in rows
             ),
-        )
-
-    def append_media_metadata(
-        self,
-        entry_key: str,
-        metadata_type: str,
-        metadata_json: str,
-    ) -> None:
-        """Insert or update a media metadata record."""
-
-        assert self.enable_media_metadata, "Adding media metadata, although not enabled"
-
-        assert self.db is not None, "Database is closed"
-
-        self.db.execute(
-            """
-            INSERT OR REPLACE INTO media_metadata (entry_key, metadata_type, metadata_json)
-            VALUES (?, ?, ?)
-            """,
-            (entry_key, metadata_type, metadata_json),
         )
 
     def append_media_metadata_batch(

--- a/src/megatron/energon/flavors/webdataset/indexing.py
+++ b/src/megatron/energon/flavors/webdataset/indexing.py
@@ -4,7 +4,7 @@
 import sqlite3
 import struct
 from collections.abc import Sequence
-from typing import BinaryIO, Generator, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, BinaryIO, Generator, List, Optional, Tuple, Union
 
 from numpy import int8
 
@@ -12,6 +12,13 @@ from megatron.energon.epathlib import EPath
 from megatron.energon.flavors.webdataset.itar import ITarRawSamplePartPointer, ITarSamplePointer
 from megatron.energon.flavors.webdataset.thread_local_sqlite import ThreadLocalSqlite
 from megatron.energon.local_copy import ensure_local_copy
+
+if TYPE_CHECKING:
+    from megatron.energon.flavors.webdataset.prepare import (
+        IndexMediaMetadata,
+        IndexSample,
+        IndexSamplePart,
+    )
 
 
 class DuplicateSampleKeyError(RuntimeError):
@@ -151,11 +158,20 @@ class SqliteIndexWriter:
 
         assert self.db is not None, "Database is closed"
 
-        self.append_samples([(tar_file_id, sample_key, sample_index, byte_offset, byte_size)])
+        try:
+            self.db.execute(
+                """
+                INSERT INTO samples (tar_file_id, sample_key, sample_index, byte_offset, byte_size)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (tar_file_id, sample_key, sample_index, byte_offset, byte_size),
+            )
+        except sqlite3.IntegrityError as exc:
+            raise DuplicateSampleKeyError(sample_key) from exc
 
     def append_samples(
         self,
-        rows: Sequence[Tuple[int8, str, int, Optional[int], Optional[int]]],
+        rows: Sequence["IndexSample"],
     ) -> None:
         """Insert multiple sample rows efficiently."""
 
@@ -173,7 +189,16 @@ class SqliteIndexWriter:
                 INSERT INTO samples (tar_file_id, sample_key, sample_index, byte_offset, byte_size)
                 VALUES (?, ?, ?, ?, ?)
                 """,
-                rows,
+                (
+                    (
+                        row.tar_file_id,
+                        row.sample_key,
+                        row.sample_index,
+                        row.byte_offset,
+                        row.byte_size,
+                    )
+                    for row in rows
+                ),
             )
             self.db.execute(f"RELEASE SAVEPOINT {savepoint_name}")
         except sqlite3.IntegrityError as exc:
@@ -194,21 +219,17 @@ class SqliteIndexWriter:
 
         assert self.db is not None, "Database is closed"
 
-        self.append_parts(
-            [
-                (
-                    tar_file_id,
-                    sample_index,
-                    part_name,
-                    content_byte_offset,
-                    content_byte_size,
-                )
-            ]
+        self.db.execute(
+            """
+            INSERT INTO sample_parts (tar_file_id, sample_index, part_name, content_byte_offset, content_byte_size)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (tar_file_id, sample_index, part_name, content_byte_offset, content_byte_size),
         )
 
     def append_parts(
         self,
-        rows: Sequence[Tuple[int8, int, str, int, int]],
+        rows: Sequence["IndexSamplePart"],
     ) -> None:
         """Insert multiple sample part rows efficiently."""
 
@@ -222,7 +243,16 @@ class SqliteIndexWriter:
             INSERT INTO sample_parts (tar_file_id, sample_index, part_name, content_byte_offset, content_byte_size)
             VALUES (?, ?, ?, ?, ?)
             """,
-            rows,
+            (
+                (
+                    row.tar_file_id,
+                    row.sample_index,
+                    row.part_name,
+                    row.content_byte_offset,
+                    row.content_byte_size,
+                )
+                for row in rows
+            ),
         )
 
     def append_media_metadata(
@@ -237,11 +267,17 @@ class SqliteIndexWriter:
 
         assert self.db is not None, "Database is closed"
 
-        self.append_media_metadata_batch([(entry_key, metadata_type, metadata_json)])
+        self.db.execute(
+            """
+            INSERT OR REPLACE INTO media_metadata (entry_key, metadata_type, metadata_json)
+            VALUES (?, ?, ?)
+            """,
+            (entry_key, metadata_type, metadata_json),
+        )
 
     def append_media_metadata_batch(
         self,
-        rows: Sequence[Tuple[str, str, str]],
+        rows: Sequence["IndexMediaMetadata"],
     ) -> None:
         """Insert or update multiple media metadata records efficiently."""
 
@@ -256,7 +292,7 @@ class SqliteIndexWriter:
             INSERT OR REPLACE INTO media_metadata (entry_key, metadata_type, metadata_json)
             VALUES (?, ?, ?)
             """,
-            rows,
+            ((row.entry_key, row.metadata_type, row.metadata_json) for row in rows),
         )
 
     def append_media_filter(self, *, strategy: str, patterns: str | None) -> None:
@@ -309,7 +345,7 @@ class SqliteIndexWriter:
 
     def _find_duplicate_sample_key(
         self,
-        rows: Sequence[Tuple[int8, str, int, Optional[int], Optional[int]]],
+        rows: Sequence["IndexSample"],
     ) -> str:
         """Resolve the sample key responsible for a uniqueness violation.
 
@@ -321,7 +357,8 @@ class SqliteIndexWriter:
         assert self.db is not None, "Database is closed"
 
         seen_in_batch: set[str] = set()
-        for _tar_file_id, sample_key, _sample_index, _byte_offset, _byte_size in rows:
+        for row in rows:
+            sample_key = row.sample_key
             if sample_key in seen_in_batch:
                 return sample_key
 
@@ -334,7 +371,7 @@ class SqliteIndexWriter:
 
             seen_in_batch.add(sample_key)
 
-        return rows[0][1]
+        return rows[0].sample_key
 
 
 class JoinIndexWriter:

--- a/src/megatron/energon/flavors/webdataset/indexing.py
+++ b/src/megatron/energon/flavors/webdataset/indexing.py
@@ -6,8 +6,6 @@ import struct
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, BinaryIO, Generator, List, Optional, Tuple, Union
 
-from numpy import int8
-
 from megatron.energon.epathlib import EPath
 from megatron.energon.flavors.webdataset.itar import ITarRawSamplePartPointer, ITarSamplePointer
 from megatron.energon.flavors.webdataset.thread_local_sqlite import ThreadLocalSqlite

--- a/src/megatron/energon/flavors/webdataset/indexing.py
+++ b/src/megatron/energon/flavors/webdataset/indexing.py
@@ -164,6 +164,8 @@ class SqliteIndexWriter:
         if len(rows) == 0:
             return
 
+        savepoint_name = "append_samples_batch"
+        self.db.execute(f"SAVEPOINT {savepoint_name}")
         try:
             # One executemany() is substantially cheaper than one execute() per row.
             self.db.executemany(
@@ -173,7 +175,11 @@ class SqliteIndexWriter:
                 """,
                 rows,
             )
+            self.db.execute(f"RELEASE SAVEPOINT {savepoint_name}")
         except sqlite3.IntegrityError as exc:
+            # executemany() may already have inserted earlier rows in the batch
+            self.db.execute(f"ROLLBACK TO SAVEPOINT {savepoint_name}")
+            self.db.execute(f"RELEASE SAVEPOINT {savepoint_name}")
             raise DuplicateSampleKeyError(self._find_duplicate_sample_key(rows)) from exc
 
     def append_part(
@@ -314,13 +320,19 @@ class SqliteIndexWriter:
 
         assert self.db is not None, "Database is closed"
 
+        seen_in_batch: set[str] = set()
         for _tar_file_id, sample_key, _sample_index, _byte_offset, _byte_size in rows:
+            if sample_key in seen_in_batch:
+                return sample_key
+
             existing = self.db.execute(
                 "SELECT 1 FROM samples WHERE sample_key = ?",
                 (sample_key,),
             ).fetchone()
             if existing is not None:
                 return sample_key
+
+            seen_in_batch.add(sample_key)
 
         return rows[0][1]
 

--- a/src/megatron/energon/flavors/webdataset/indexing.py
+++ b/src/megatron/energon/flavors/webdataset/indexing.py
@@ -173,7 +173,7 @@ class SqliteIndexWriter:
                 """,
                 rows,
             )
-        except sqlite3.IntegrityError as exc:  # pragma: no cover - defensive programming
+        except sqlite3.IntegrityError as exc:
             raise DuplicateSampleKeyError(self._find_duplicate_sample_key(rows)) from exc
 
     def append_part(

--- a/src/megatron/energon/flavors/webdataset/indexing.py
+++ b/src/megatron/energon/flavors/webdataset/indexing.py
@@ -3,6 +3,7 @@
 
 import sqlite3
 import struct
+from collections.abc import Sequence
 from typing import BinaryIO, Generator, List, Optional, Tuple, Union
 
 from numpy import int8
@@ -150,17 +151,30 @@ class SqliteIndexWriter:
 
         assert self.db is not None, "Database is closed"
 
-        # Insert a row in the samples table
+        self.append_samples([(tar_file_id, sample_key, sample_index, byte_offset, byte_size)])
+
+    def append_samples(
+        self,
+        rows: Sequence[Tuple[int8, str, int, Optional[int], Optional[int]]],
+    ) -> None:
+        """Insert multiple sample rows efficiently."""
+
+        assert self.db is not None, "Database is closed"
+
+        if len(rows) == 0:
+            return
+
         try:
-            self.db.execute(
+            # One executemany() is substantially cheaper than one execute() per row.
+            self.db.executemany(
                 """
                 INSERT INTO samples (tar_file_id, sample_key, sample_index, byte_offset, byte_size)
                 VALUES (?, ?, ?, ?, ?)
                 """,
-                (tar_file_id, sample_key, sample_index, byte_offset, byte_size),
+                rows,
             )
         except sqlite3.IntegrityError as exc:  # pragma: no cover - defensive programming
-            raise DuplicateSampleKeyError(sample_key) from exc
+            raise DuplicateSampleKeyError(self._find_duplicate_sample_key(rows)) from exc
 
     def append_part(
         self,
@@ -174,13 +188,35 @@ class SqliteIndexWriter:
 
         assert self.db is not None, "Database is closed"
 
-        # Insert a row in the sample parts table
-        self.db.execute(
+        self.append_parts(
+            [
+                (
+                    tar_file_id,
+                    sample_index,
+                    part_name,
+                    content_byte_offset,
+                    content_byte_size,
+                )
+            ]
+        )
+
+    def append_parts(
+        self,
+        rows: Sequence[Tuple[int8, int, str, int, int]],
+    ) -> None:
+        """Insert multiple sample part rows efficiently."""
+
+        assert self.db is not None, "Database is closed"
+
+        if len(rows) == 0:
+            return
+
+        self.db.executemany(
             """
             INSERT INTO sample_parts (tar_file_id, sample_index, part_name, content_byte_offset, content_byte_size)
             VALUES (?, ?, ?, ?, ?)
             """,
-            (tar_file_id, sample_index, part_name, content_byte_offset, content_byte_size),
+            rows,
         )
 
     def append_media_metadata(
@@ -195,12 +231,26 @@ class SqliteIndexWriter:
 
         assert self.db is not None, "Database is closed"
 
-        self.db.execute(
+        self.append_media_metadata_batch([(entry_key, metadata_type, metadata_json)])
+
+    def append_media_metadata_batch(
+        self,
+        rows: Sequence[Tuple[str, str, str]],
+    ) -> None:
+        """Insert or update multiple media metadata records efficiently."""
+
+        assert self.enable_media_metadata, "Adding media metadata, although not enabled"
+        assert self.db is not None, "Database is closed"
+
+        if len(rows) == 0:
+            return
+
+        self.db.executemany(
             """
             INSERT OR REPLACE INTO media_metadata (entry_key, metadata_type, metadata_json)
             VALUES (?, ?, ?)
             """,
-            (entry_key, metadata_type, metadata_json),
+            rows,
         )
 
     def append_media_filter(self, *, strategy: str, patterns: str | None) -> None:
@@ -250,6 +300,29 @@ class SqliteIndexWriter:
     def __exit__(self, exc_type, exc_val, exc_tb):
         # If an exception occurred, do not finalize (so you can inspect the temp file)
         self.close()
+
+    def _find_duplicate_sample_key(
+        self,
+        rows: Sequence[Tuple[int8, str, int, Optional[int], Optional[int]]],
+    ) -> str:
+        """Resolve the sample key responsible for a uniqueness violation.
+
+        sqlite3 only tells us that *some* row in the batch violated the unique
+        constraint. We do a targeted follow-up lookup so the caller still gets
+        the concrete duplicate key in the raised error.
+        """
+
+        assert self.db is not None, "Database is closed"
+
+        for _tar_file_id, sample_key, _sample_index, _byte_offset, _byte_size in rows:
+            existing = self.db.execute(
+                "SELECT 1 FROM samples WHERE sample_key = ?",
+                (sample_key,),
+            ).fetchone()
+            if existing is not None:
+                return sample_key
+
+        return rows[0][1]
 
 
 class JoinIndexWriter:

--- a/src/megatron/energon/flavors/webdataset/prepare.py
+++ b/src/megatron/energon/flavors/webdataset/prepare.py
@@ -9,7 +9,6 @@ import re
 import sys
 import tarfile
 import uuid
-from dataclasses import asdict
 from pathlib import Path
 from typing import (
     Any,
@@ -58,6 +57,7 @@ from megatron.energon.typed_converter import to_json_object
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", covariant=True)
+_INDEX_BATCH_SIZE = 4096
 
 
 @edataclass
@@ -99,6 +99,15 @@ class IndexMediaMetadata(IndexAggregatable):
 class IndexShardInfo(IndexAggregatable):
     shard_info: ShardInfo
     parts: Set[str]
+
+
+@edataclass
+class IndexBatch(IndexAggregatable):
+    """A chunk of rows produced by one worker and consumed by the SQLite aggregator."""
+
+    samples: Tuple[Tuple[int, str, int, int, int], ...]
+    sample_parts: Tuple[Tuple[int, int, str, int, int], ...]
+    media_metadata: Tuple[Tuple[str, str, str], ...]
 
 
 class SqliteIndexWriterAggregator(
@@ -163,11 +172,38 @@ class SqliteIndexWriterAggregator(
         aggregator_pool: AggregatorPool,
     ) -> None:
         assert self.writer is not None, "Writer is not initialized."
-        if isinstance(item, IndexSample):
-            self.writer.append_sample(**asdict(item))
+        if isinstance(item, IndexBatch):
+            # IndexBatch can be partial, e.g. it can contain only sample_parts without samples,
+            # so we check each of them before writing.
+            if item.samples:
+                self.writer.append_samples(item.samples)
+            if item.sample_parts:
+                self.writer.append_parts(item.sample_parts)
+            if item.media_metadata:
+                self.writer.append_media_metadata_batch(item.media_metadata)
+            if item.samples or item.sample_parts or item.media_metadata:
+                self.had_update = True
+            self.media_metadata_written += len(item.media_metadata)
+            if self.progress_on_media:
+                self._advance_progress(count=len(item.media_metadata))
+        elif isinstance(item, IndexSample):
+            self.writer.append_sample(
+                tar_file_id=item.tar_file_id,
+                sample_key=item.sample_key,
+                sample_index=item.sample_index,
+                byte_offset=item.byte_offset,
+                byte_size=item.byte_size,
+            )
             self.had_update = True
         elif isinstance(item, IndexSamplePart):
-            self.writer.append_part(**asdict(item))
+            self.writer.append_part(
+                tar_file_id=item.tar_file_id,
+                sample_index=item.sample_index,
+                part_name=item.part_name,
+                content_byte_offset=item.content_byte_offset,
+                content_byte_size=item.content_byte_size,
+            )
+            self.had_update = True
         elif isinstance(item, IndexMediaMetadata):
             self.writer.append_media_metadata(
                 entry_key=item.entry_key,
@@ -204,11 +240,12 @@ class SqliteIndexWriterAggregator(
         assert self.writer is not None, "Writer is not initialized."
         return self.shards, self.found_parts, self.had_update
 
-    def _advance_progress(self) -> None:
-        try:
-            next(self.prog_iter)
-        except StopIteration:
-            pass
+    def _advance_progress(self, *, count: int = 1) -> None:
+        for _ in range(count):
+            try:
+                next(self.prog_iter)
+            except StopIteration:
+                break
 
 
 class WebdatasetPreparator:
@@ -263,6 +300,36 @@ class WebdatasetPreparator:
         shard_info = ShardInfo(name=path, path=parent_path / path, count=0)
 
         try:
+            # These buffers are local to one worker and one shard. Once they
+            # reach the threshold below, they are emitted as a single IndexBatch.
+            sample_rows: list[tuple[int, str, int, int, int]] = []
+            sample_part_rows: list[tuple[int, int, str, int, int]] = []
+            media_metadata_rows: list[tuple[str, str, str]] = []
+
+            def flush_batch() -> IndexBatch | None:
+                if not sample_rows and not sample_part_rows and not media_metadata_rows:
+                    return None
+                batch = IndexBatch(
+                    samples=tuple(sample_rows),
+                    sample_parts=tuple(sample_part_rows),
+                    media_metadata=tuple(media_metadata_rows),
+                )
+                sample_rows.clear()
+                sample_part_rows.clear()
+                media_metadata_rows.clear()
+                return batch
+
+            def append_completed_sample(next_index_sample: dict[str, int | str]) -> None:
+                sample_rows.append(
+                    (
+                        int(next_index_sample["tar_file_id"]),
+                        str(next_index_sample["sample_key"]),
+                        int(next_index_sample["sample_index"]),
+                        int(next_index_sample["byte_offset"]),
+                        int(next_index_sample["byte_size"]),
+                    )
+                )
+
             # Note: Write to .tmp file first, then remove .tmp extension, to make sure only complete
             # files are used.
             tar: tarfile.TarFile
@@ -296,7 +363,7 @@ class WebdatasetPreparator:
                                 next_index_sample["byte_size"] = (
                                     member.offset - next_index_sample["byte_offset"]
                                 )
-                                yield IndexSample(**next_index_sample)
+                                append_completed_sample(next_index_sample)
 
                             next_index_sample = dict(
                                 tar_file_id=shard_to_idx[path],
@@ -309,13 +376,14 @@ class WebdatasetPreparator:
 
                         entry_key = f"{base_name}.{part_name}"
 
-                        # Yield this part of the sample to the aggregator
-                        yield IndexSamplePart(
-                            tar_file_id=shard_to_idx[path],
-                            sample_index=count - 1,
-                            part_name=part_name,
-                            content_byte_offset=member.offset_data,
-                            content_byte_size=member.size,
+                        sample_part_rows.append(
+                            (
+                                shard_to_idx[path],
+                                count - 1,
+                                part_name,
+                                member.offset_data,
+                                member.size,
+                            )
                         )
 
                         if media_filter is not None:
@@ -332,11 +400,24 @@ class WebdatasetPreparator:
                                     stored_type, metadata_json = serialize_media_metadata(
                                         extracted_metadata
                                     )
-                                    yield IndexMediaMetadata(
-                                        entry_key=entry_key,
-                                        metadata_type=stored_type.value,
-                                        metadata_json=metadata_json,
+                                    media_metadata_rows.append(
+                                        (
+                                            entry_key,
+                                            stored_type.value,
+                                            metadata_json,
+                                        )
                                     )
+
+                        # We batch across all row types, because all of them were
+                        # previously sent as individual queue messages to one
+                        # serialized SQLite writer.
+                        if (
+                            len(sample_rows) + len(sample_part_rows) + len(media_metadata_rows)
+                            >= _INDEX_BATCH_SIZE
+                        ):
+                            batch = flush_batch()
+                            if batch is not None:
+                                yield batch
 
                     shard_info.count = count
                     iw.append(tar.offset)
@@ -344,7 +425,12 @@ class WebdatasetPreparator:
                         next_index_sample["byte_size"] = (
                             tar.offset - next_index_sample["byte_offset"]
                         )
-                        yield IndexSample(**next_index_sample)
+                        append_completed_sample(next_index_sample)
+                    # Flush the tail of the shard so the aggregator sees all
+                    # rows before it receives the final IndexShardInfo message.
+                    batch = flush_batch()
+                    if batch is not None:
+                        yield batch
             yield IndexShardInfo(shard_info=shard_info, parts=parts)
             return
         except BaseException:
@@ -365,6 +451,19 @@ class WebdatasetPreparator:
         shard_path = parent_path / path
 
         try:
+            media_metadata_rows: list[tuple[str, str, str]] = []
+
+            def flush_batch() -> IndexBatch | None:
+                if not media_metadata_rows:
+                    return None
+                batch = IndexBatch(
+                    samples=(),
+                    sample_parts=(),
+                    media_metadata=tuple(media_metadata_rows),
+                )
+                media_metadata_rows.clear()
+                return batch
+
             with shard_path.open("rb") as handle:
                 with tarfile.open(fileobj=handle, mode="r:*") as tar:
                     for (
@@ -390,11 +489,24 @@ class WebdatasetPreparator:
 
                         stored_type, metadata_json = serialize_media_metadata(extracted_metadata)
 
-                        yield IndexMediaMetadata(
-                            entry_key=entry_key,
-                            metadata_type=stored_type.value,
-                            metadata_json=metadata_json,
+                        media_metadata_rows.append(
+                            (
+                                entry_key,
+                                stored_type.value,
+                                metadata_json,
+                            )
                         )
+
+                        if len(media_metadata_rows) >= _INDEX_BATCH_SIZE:
+                            batch = flush_batch()
+                            if batch is not None:
+                                yield batch
+
+                    # Media-only extraction uses the same batching mechanism so
+                    # filesystem- and tar-backed media metadata follow one write path.
+                    batch = flush_batch()
+                    if batch is not None:
+                        yield batch
 
         except BaseException:  # pragma: no cover - dependent on malformed archives
             logger.exception(

--- a/src/megatron/energon/flavors/webdataset/prepare.py
+++ b/src/megatron/energon/flavors/webdataset/prepare.py
@@ -35,6 +35,7 @@ from megatron.energon.epathlib import EPath
 from megatron.energon.eyaml import load_yaml
 from megatron.energon.flavors.webdataset.aggregator_pool import AggregatorPool, BaseAggregator
 from megatron.energon.flavors.webdataset.config import (
+    INDEX_BATCH_SIZE,
     INDEX_SQLITE_FILENAME,
     INDEX_UUID_FILENAME,
     INFO_JSON_FILENAME,
@@ -54,7 +55,6 @@ from megatron.energon.typed_converter import to_json_object
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", covariant=True)
-_INDEX_BATCH_SIZE = 4096
 
 
 @edataclass
@@ -582,7 +582,7 @@ class WebdatasetPreparator:
             num_workers=workers,
             user_produce_data=process_tar,
             aggregator=aggregator,
-            batch_size=_INDEX_BATCH_SIZE,
+            batch_size=INDEX_BATCH_SIZE,
         )
 
         for path in paths:
@@ -784,7 +784,7 @@ class WebdatasetPreparator:
             num_workers=min(workers, len(expanded_paths)) or 1,
             user_produce_data=process_tar,
             aggregator=aggregator,
-            batch_size=_INDEX_BATCH_SIZE,
+            batch_size=INDEX_BATCH_SIZE,
         )
 
         for path in expanded_paths:

--- a/src/megatron/energon/flavors/webdataset/prepare.py
+++ b/src/megatron/energon/flavors/webdataset/prepare.py
@@ -43,10 +43,7 @@ from megatron.energon.flavors.webdataset.config import (
     skip_meta_re,
     split_name_re,
 )
-from megatron.energon.flavors.webdataset.indexing import (
-    DuplicateSampleKeyError,
-    SqliteIndexWriter,
-)
+from megatron.energon.flavors.webdataset.indexing import DuplicateSampleKeyError, SqliteIndexWriter
 from megatron.energon.flavors.webdataset.itar import TarIndexWriter
 from megatron.energon.flavors.webdataset.metadata import get_dataset_info
 from megatron.energon.flavors.webdataset.structs import ShardInfo, WebdatasetInfo, WebdatasetSplits
@@ -99,15 +96,6 @@ class IndexMediaMetadata(IndexAggregatable):
 class IndexShardInfo(IndexAggregatable):
     shard_info: ShardInfo
     parts: Set[str]
-
-
-@edataclass
-class IndexBatch(IndexAggregatable):
-    """A chunk of rows produced by one worker and consumed by the SQLite aggregator."""
-
-    samples: Tuple[Tuple[int, str, int, int, int], ...]
-    sample_parts: Tuple[Tuple[int, int, str, int, int], ...]
-    media_metadata: Tuple[Tuple[str, str, str], ...]
 
 
 class SqliteIndexWriterAggregator(
@@ -168,62 +156,54 @@ class SqliteIndexWriterAggregator(
 
     def on_item(
         self,
-        item: IndexAggregatable,
+        items: List[IndexAggregatable],
         aggregator_pool: AggregatorPool,
     ) -> None:
         assert self.writer is not None, "Writer is not initialized."
-        if isinstance(item, IndexBatch):
-            # IndexBatch can be partial, e.g. it can contain only sample_parts without samples,
-            # so we check each of them before writing.
-            if item.samples:
-                self.writer.append_samples(item.samples)
-            if item.sample_parts:
-                self.writer.append_parts(item.sample_parts)
-            if item.media_metadata:
-                self.writer.append_media_metadata_batch(item.media_metadata)
-            if item.samples or item.sample_parts or item.media_metadata:
-                self.had_update = True
-            self.media_metadata_written += len(item.media_metadata)
-            if self.progress_on_media:
-                self._advance_progress(count=len(item.media_metadata))
-        elif isinstance(item, IndexSample):
-            self.writer.append_sample(
-                tar_file_id=item.tar_file_id,
-                sample_key=item.sample_key,
-                sample_index=item.sample_index,
-                byte_offset=item.byte_offset,
-                byte_size=item.byte_size,
-            )
-            self.had_update = True
-        elif isinstance(item, IndexSamplePart):
-            self.writer.append_part(
-                tar_file_id=item.tar_file_id,
-                sample_index=item.sample_index,
-                part_name=item.part_name,
-                content_byte_offset=item.content_byte_offset,
-                content_byte_size=item.content_byte_size,
-            )
-            self.had_update = True
-        elif isinstance(item, IndexMediaMetadata):
-            self.writer.append_media_metadata(
-                entry_key=item.entry_key,
-                metadata_type=item.metadata_type,
-                metadata_json=item.metadata_json,
-            )
-            self.had_update = True
-            self.media_metadata_written += 1
-            if self.progress_on_media:
-                self._advance_progress()
-        elif isinstance(item, IndexShardInfo):
-            # This is a (shard_info, parts) tuple
-            if not self.progress_on_media:
-                self._advance_progress()
+        sample_rows: List[IndexSample] = []
+        sample_part_rows: List[IndexSamplePart] = []
+        media_metadata_rows: List[IndexMediaMetadata] = []
 
-            shard_info, cur_parts = item.shard_info, item.parts
-            assert shard_info.count != 0, f"Shard {shard_info.name} has no samples."
-            self.shards.append(shard_info)
-            if len(self.found_parts) < 50:
-                self.found_parts.update(cur_parts)
+        def flush_rows() -> None:
+            if sample_rows:
+                self.writer.append_samples(sample_rows)
+            if sample_part_rows:
+                self.writer.append_parts(sample_part_rows)
+            if media_metadata_rows:
+                self.writer.append_media_metadata_batch(media_metadata_rows)
+
+            if sample_rows or sample_part_rows or media_metadata_rows:
+                self.had_update = True
+                self.media_metadata_written += len(media_metadata_rows)
+                if self.progress_on_media and media_metadata_rows:
+                    self._advance_progress(count=len(media_metadata_rows))
+
+            sample_rows.clear()
+            sample_part_rows.clear()
+            media_metadata_rows.clear()
+
+        for item in items:
+            if isinstance(item, IndexSample):
+                sample_rows.append(item)
+            elif isinstance(item, IndexSamplePart):
+                sample_part_rows.append(item)
+            elif isinstance(item, IndexMediaMetadata):
+                media_metadata_rows.append(item)
+            elif isinstance(item, IndexShardInfo):
+                flush_rows()
+
+                if not self.progress_on_media:
+                    self._advance_progress()
+
+                shard_info, cur_parts = item.shard_info, item.parts
+                assert shard_info.count != 0, f"Shard {shard_info.name} has no samples."
+                self.shards.append(shard_info)
+                if len(self.found_parts) < 50:
+                    self.found_parts.update(cur_parts)
+            else:
+                raise TypeError(f"Unsupported index item type: {type(item)!r}")
+
+        flush_rows()
 
     def on_finish(self, aggregator_pool: AggregatorPool) -> None:
         assert self.writer is not None, "Writer is not initialized."
@@ -294,42 +274,12 @@ class WebdatasetPreparator:
             A generator of items that will be processed by SqliteIndexWriterAggregator.
             See method `on_item` of SqliteIndexWriterAggregator.
             The items are either:
-            - A sample dictionary with information about the offset, key etc.
-            - Or a tuple of shard info and a set of found parts for statistics.
+            - typed row objects describing samples, sample parts, or media metadata
+            - or shard info for statistics.
         """
         shard_info = ShardInfo(name=path, path=parent_path / path, count=0)
 
         try:
-            # These buffers are local to one worker and one shard. Once they
-            # reach the threshold below, they are emitted as a single IndexBatch.
-            sample_rows: list[tuple[int, str, int, int, int]] = []
-            sample_part_rows: list[tuple[int, int, str, int, int]] = []
-            media_metadata_rows: list[tuple[str, str, str]] = []
-
-            def flush_batch() -> IndexBatch | None:
-                if not sample_rows and not sample_part_rows and not media_metadata_rows:
-                    return None
-                batch = IndexBatch(
-                    samples=tuple(sample_rows),
-                    sample_parts=tuple(sample_part_rows),
-                    media_metadata=tuple(media_metadata_rows),
-                )
-                sample_rows.clear()
-                sample_part_rows.clear()
-                media_metadata_rows.clear()
-                return batch
-
-            def append_completed_sample(next_index_sample: dict[str, int | str]) -> None:
-                sample_rows.append(
-                    (
-                        int(next_index_sample["tar_file_id"]),
-                        str(next_index_sample["sample_key"]),
-                        int(next_index_sample["sample_index"]),
-                        int(next_index_sample["byte_offset"]),
-                        int(next_index_sample["byte_size"]),
-                    )
-                )
-
             # Note: Write to .tmp file first, then remove .tmp extension, to make sure only complete
             # files are used.
             tar: tarfile.TarFile
@@ -363,7 +313,7 @@ class WebdatasetPreparator:
                                 next_index_sample["byte_size"] = (
                                     member.offset - next_index_sample["byte_offset"]
                                 )
-                                append_completed_sample(next_index_sample)
+                                yield IndexSample(**next_index_sample)
 
                             next_index_sample = dict(
                                 tar_file_id=shard_to_idx[path],
@@ -376,14 +326,12 @@ class WebdatasetPreparator:
 
                         entry_key = f"{base_name}.{part_name}"
 
-                        sample_part_rows.append(
-                            (
-                                shard_to_idx[path],
-                                count - 1,
-                                part_name,
-                                member.offset_data,
-                                member.size,
-                            )
+                        yield IndexSamplePart(
+                            tar_file_id=shard_to_idx[path],
+                            sample_index=count - 1,
+                            part_name=part_name,
+                            content_byte_offset=member.offset_data,
+                            content_byte_size=member.size,
                         )
 
                         if media_filter is not None:
@@ -400,24 +348,11 @@ class WebdatasetPreparator:
                                     stored_type, metadata_json = serialize_media_metadata(
                                         extracted_metadata
                                     )
-                                    media_metadata_rows.append(
-                                        (
-                                            entry_key,
-                                            stored_type.value,
-                                            metadata_json,
-                                        )
+                                    yield IndexMediaMetadata(
+                                        entry_key=entry_key,
+                                        metadata_type=stored_type.value,
+                                        metadata_json=metadata_json,
                                     )
-
-                        # We batch across all row types, because all of them were
-                        # previously sent as individual queue messages to one
-                        # serialized SQLite writer.
-                        if (
-                            len(sample_rows) + len(sample_part_rows) + len(media_metadata_rows)
-                            >= _INDEX_BATCH_SIZE
-                        ):
-                            batch = flush_batch()
-                            if batch is not None:
-                                yield batch
 
                     shard_info.count = count
                     iw.append(tar.offset)
@@ -425,12 +360,7 @@ class WebdatasetPreparator:
                         next_index_sample["byte_size"] = (
                             tar.offset - next_index_sample["byte_offset"]
                         )
-                        append_completed_sample(next_index_sample)
-                    # Flush the tail of the shard so the aggregator sees all
-                    # rows before it receives the final IndexShardInfo message.
-                    batch = flush_batch()
-                    if batch is not None:
-                        yield batch
+                        yield IndexSample(**next_index_sample)
             yield IndexShardInfo(shard_info=shard_info, parts=parts)
             return
         except BaseException:
@@ -451,19 +381,6 @@ class WebdatasetPreparator:
         shard_path = parent_path / path
 
         try:
-            media_metadata_rows: list[tuple[str, str, str]] = []
-
-            def flush_batch() -> IndexBatch | None:
-                if not media_metadata_rows:
-                    return None
-                batch = IndexBatch(
-                    samples=(),
-                    sample_parts=(),
-                    media_metadata=tuple(media_metadata_rows),
-                )
-                media_metadata_rows.clear()
-                return batch
-
             with shard_path.open("rb") as handle:
                 with tarfile.open(fileobj=handle, mode="r:*") as tar:
                     for (
@@ -489,24 +406,11 @@ class WebdatasetPreparator:
 
                         stored_type, metadata_json = serialize_media_metadata(extracted_metadata)
 
-                        media_metadata_rows.append(
-                            (
-                                entry_key,
-                                stored_type.value,
-                                metadata_json,
-                            )
+                        yield IndexMediaMetadata(
+                            entry_key=entry_key,
+                            metadata_type=stored_type.value,
+                            metadata_json=metadata_json,
                         )
-
-                        if len(media_metadata_rows) >= _INDEX_BATCH_SIZE:
-                            batch = flush_batch()
-                            if batch is not None:
-                                yield batch
-
-                    # Media-only extraction uses the same batching mechanism so
-                    # filesystem- and tar-backed media metadata follow one write path.
-                    batch = flush_batch()
-                    if batch is not None:
-                        yield batch
 
         except BaseException:  # pragma: no cover - dependent on malformed archives
             logger.exception(
@@ -678,6 +582,7 @@ class WebdatasetPreparator:
             num_workers=workers,
             user_produce_data=process_tar,
             aggregator=aggregator,
+            batch_size=_INDEX_BATCH_SIZE,
         )
 
         for path in paths:
@@ -879,6 +784,7 @@ class WebdatasetPreparator:
             num_workers=min(workers, len(expanded_paths)) or 1,
             user_produce_data=process_tar,
             aggregator=aggregator,
+            batch_size=_INDEX_BATCH_SIZE,
         )
 
         for path in expanded_paths:

--- a/src/megatron/energon/media/filesystem_prepare.py
+++ b/src/megatron/energon/media/filesystem_prepare.py
@@ -10,7 +10,11 @@ from typing import Callable, Iterator
 
 from megatron.energon.epathlib import EPath
 from megatron.energon.flavors.webdataset.aggregator_pool import AggregatorPool
-from megatron.energon.flavors.webdataset.config import INDEX_SQLITE_FILENAME, MAIN_FOLDER_NAME
+from megatron.energon.flavors.webdataset.config import (
+    INDEX_BATCH_SIZE,
+    INDEX_SQLITE_FILENAME,
+    MAIN_FOLDER_NAME,
+)
 from megatron.energon.flavors.webdataset.prepare import (
     IndexAggregatable,
     IndexMediaMetadata,
@@ -83,6 +87,7 @@ def prepare_filesystem_dataset(
             media_filter=media_filter,
         ),
         aggregator=aggregator,
+        batch_size=INDEX_BATCH_SIZE,
     )
 
     for file_path in files:

--- a/tests/test_webdataset_prepare.py
+++ b/tests/test_webdataset_prepare.py
@@ -25,12 +25,16 @@ class TestSqliteIndexWriterBatching(unittest.TestCase):
             with self.assertRaises(DuplicateSampleKeyError) as exc:
                 writer.append_samples(
                     [
-                        (0, "duplicate", 0, 0, 10),
-                        (1, "duplicate", 0, 10, 10),
+                        (0, "first", 0, 0, 10),
+                        (0, "duplicate", 1, 10, 10),
+                        (1, "duplicate", 0, 20, 10),
                     ]
                 )
+            assert writer.db is not None
+            row_count = writer.db.execute("SELECT COUNT(*) FROM samples").fetchone()[0]
 
         self.assertEqual(exc.exception.sample_key, "duplicate")
+        self.assertEqual(row_count, 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_webdataset_prepare.py
+++ b/tests/test_webdataset_prepare.py
@@ -6,10 +6,24 @@ import unittest
 from pathlib import Path
 
 from megatron.energon.epathlib import EPath
-from megatron.energon.flavors.webdataset.indexing import (
-    DuplicateSampleKeyError,
-    SqliteIndexWriter,
-)
+from megatron.energon.flavors.webdataset.aggregator_pool import AggregatorPool, BaseAggregator
+from megatron.energon.flavors.webdataset.indexing import DuplicateSampleKeyError, SqliteIndexWriter
+from megatron.energon.flavors.webdataset.prepare import IndexSample
+
+
+def produce_items(task: list[int]):
+    yield from task
+
+
+class BatchCollector(BaseAggregator[int, list[list[int]]]):
+    def __init__(self):
+        self.batches: list[list[int]] = []
+
+    def on_item(self, items: list[int], aggregator_pool: AggregatorPool) -> None:
+        self.batches.append(list(items))
+
+    def get_final_result_data(self) -> list[list[int]]:
+        return self.batches
 
 
 class TestSqliteIndexWriterBatching(unittest.TestCase):
@@ -25,9 +39,27 @@ class TestSqliteIndexWriterBatching(unittest.TestCase):
             with self.assertRaises(DuplicateSampleKeyError) as exc:
                 writer.append_samples(
                     [
-                        (0, "first", 0, 0, 10),
-                        (0, "duplicate", 1, 10, 10),
-                        (1, "duplicate", 0, 20, 10),
+                        IndexSample(
+                            tar_file_id=0,
+                            sample_key="first",
+                            sample_index=0,
+                            byte_offset=0,
+                            byte_size=10,
+                        ),
+                        IndexSample(
+                            tar_file_id=0,
+                            sample_key="duplicate",
+                            sample_index=1,
+                            byte_offset=10,
+                            byte_size=10,
+                        ),
+                        IndexSample(
+                            tar_file_id=1,
+                            sample_key="duplicate",
+                            sample_index=0,
+                            byte_offset=20,
+                            byte_size=10,
+                        ),
                     ]
                 )
             assert writer.db is not None
@@ -35,6 +67,18 @@ class TestSqliteIndexWriterBatching(unittest.TestCase):
 
         self.assertEqual(exc.exception.sample_key, "duplicate")
         self.assertEqual(row_count, 0)
+
+    def test_aggregator_pool_batches_worker_output(self):
+        pool = AggregatorPool(
+            num_workers=1,
+            user_produce_data=produce_items,
+            aggregator=BatchCollector(),
+            batch_size=2,
+        )
+        pool.submit_task([1, 2, 3])
+        pool.submit_task([4, 5])
+
+        self.assertEqual(pool.process(), [[1, 2], [3], [4, 5]])
 
 
 if __name__ == "__main__":

--- a/tests/test_webdataset_prepare.py
+++ b/tests/test_webdataset_prepare.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from megatron.energon.epathlib import EPath
+from megatron.energon.flavors.webdataset.indexing import (
+    DuplicateSampleKeyError,
+    SqliteIndexWriter,
+)
+
+
+class TestSqliteIndexWriterBatching(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.sqlite_path = EPath(Path(self.temp_dir.name) / "index.sqlite")
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_append_samples_batch_reports_duplicate_sample_key(self):
+        with SqliteIndexWriter(self.sqlite_path) as writer:
+            with self.assertRaises(DuplicateSampleKeyError) as exc:
+                writer.append_samples(
+                    [
+                        (0, "duplicate", 0, 0, 10),
+                        (1, "duplicate", 0, 10, 10),
+                    ]
+                )
+
+        self.assertEqual(exc.exception.sample_key, "duplicate")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Reduce `prepare_dataset()` indexing overhead by batching worker output and SQLite writes, giving massive speed increase on large, multi-worker scenarios.

## Motivation

`prepare_dataset()` already parallelizes shard scanning, but workers were still sending one item at a time to a single SQLite writer process. That left a lot of overhead in:

- multiprocessing queue traffic
- Python object handling in the aggregator
- one-row-at-a-time SQLite inserts

For larger datasets, that becomes a noticeable bottleneck during dataset preparation (prepare took ~30h for a 2B sequence dataset with 128 workers on a 2TB RAM + 128-core VM).

## Changes

- add an internal `IndexBatch` payload for batched worker (aggregator communication)
- batch sample, sample-part, and media-metadata rows in the worker before flushing
- switch the SQLite writer to bulk inserts via `executemany()`
- preserve duplicate-key reporting for batched sample inserts
- unit test for batched duplicate reporting

 ## Benchmark

Synthetic benchmark:
- 400k samples
- 40 shards

| workers | before | after |
| --- | ---: | ---: |
| 1 | 67.247s | 40.137 |
| 4 | 24.707s | 11.294s |
| 8 | 19.593s | 6.451s |