### PR TITLE
Expose enable_sample_tables in prepare_dataset and as --no-sample-tables CLI flag

### DIFF
--- a/docs/source/advanced/data_prep_api.md
+++ b/docs/source/advanced/data_prep_api.md
@@ -71,22 +71,4 @@ if __name__ == "__main__":
 
 ## Skipping the SQLite samples tables for very large datasets
 
-`prepare_dataset` accepts an `enable_sample_tables` kwarg (default `True`). On very large datasets (100M+ samples) the SQLite inserts and post-load btree builds for the `samples` and `sample_parts` tables can dominate preparation runtime. If the dataset is consumed purely sequentially via the integer-indexed loader (`ShardInfosITarReader`), those tables are never queried at training time, and you can skip populating them by passing `enable_sample_tables=False`:
-
-```python
-BaseWebdatasetFactory.prepare_dataset(
-    path,
-    all_tars,
-    split_parts_ratio=split_parts_ratio,
-    progress_fn=progress_fn,
-    workers=num_workers,
-    enable_sample_tables=False,
-)
-```
-
-`.tar.idx`, `.info.json` and the split config are still produced.
-
-```{admonition} Trade-off
-:class: warning
-With `enable_sample_tables=False`, sample-key lookups are unavailable. This breaks polylithic dataset joins (built via SQL `JOIN` over the `samples` tables), `as_file_store()` / `WebdatasetFileStore` access (used for aux-data on crude datasets and by `energon mount`), and any direct `SqliteIndexReader` queries. Failures are loud (`sqlite3.OperationalError: no such table: samples`).
-```
+Pass `enable_sample_tables=False` to `prepare_dataset` (default `True`) to skip populating the `samples` and `sample_parts` tables. Useful when preparation is bottlenecked by SQLite indexing on very large datasets. A dataset prepared this way cannot be used as an [auxiliary dataset](aux-data).

--- a/docs/source/advanced/data_prep_api.md
+++ b/docs/source/advanced/data_prep_api.md
@@ -68,3 +68,25 @@ Then, run the script:
 if __name__ == "__main__":
     prepare_one_dataset(Path("/path/to/dataset"), 16, Path("/path/to/template_dir"))
 ```
+
+## Skipping the SQLite samples tables for very large datasets
+
+`prepare_dataset` accepts an `enable_sample_tables` kwarg (default `True`). On very large datasets (100M+ samples) the SQLite inserts and post-load btree builds for the `samples` and `sample_parts` tables can dominate preparation runtime. If the dataset is consumed purely sequentially via the integer-indexed loader (`ShardInfosITarReader`), those tables are never queried at training time, and you can skip populating them by passing `enable_sample_tables=False`:
+
+```python
+BaseWebdatasetFactory.prepare_dataset(
+    path,
+    all_tars,
+    split_parts_ratio=split_parts_ratio,
+    progress_fn=progress_fn,
+    workers=num_workers,
+    enable_sample_tables=False,
+)
+```
+
+`.tar.idx`, `.info.json` and the split config are still produced.
+
+```{admonition} Trade-off
+:class: warning
+With `enable_sample_tables=False`, sample-key lookups are unavailable. This breaks polylithic dataset joins (built via SQL `JOIN` over the `samples` tables), `as_file_store()` / `WebdatasetFileStore` access (used for aux-data on crude datasets and by `energon mount`), and any direct `SqliteIndexReader` queries. Failures are loud (`sqlite3.OperationalError: no such table: samples`).
+```

--- a/docs/source/basic/data_prep.md
+++ b/docs/source/basic/data_prep.md
@@ -688,13 +688,13 @@ The `media_metadata` table is used to store the media metadata for the selected 
 
 #### Skipping the samples tables for very large datasets
 
-For very large datasets (100M+ samples), populating the `samples` and `sample_parts` tables can dominate `energon prepare` runtime. If the dataset will only be consumed sequentially (not as an auxiliary dataset), you can skip these tables:
+For very large datasets (100M+ samples), populating the `samples` and `sample_parts` tables can dominate `energon prepare` runtime. If the dataset will not be used as an auxiliary dataset or mounted, you can skip these tables:
 
 ```sh
 > energon prepare --no-sample-tables /path/to/dataset
 ```
 
-A dataset prepared this way cannot be used as an [auxiliary dataset](aux-data).
+A dataset prepared this way cannot be used as an [auxiliary dataset](aux-data) or with `energon mount`.
 
 (data-on-disk-jsonl)=
 ## Dataset Format on Disk for JSONL Datasets

--- a/docs/source/basic/data_prep.md
+++ b/docs/source/basic/data_prep.md
@@ -686,6 +686,28 @@ The `media_metadata` table is used to store the media metadata for the selected 
 | 00002.mp4 | ... | ... |
 
 
+#### Skipping the samples tables for very large datasets
+
+On very large datasets (100M+ samples) the `samples` and `sample_parts` table inserts, combined with the post-load btree index builds over the unique `sample_key`, can dominate `energon prepare` runtime. For datasets that are consumed purely sequentially via the integer-indexed loader (`ShardInfosITarReader` — the default loader for monolithic webdatasets), those tables are never queried at training time: shard cumulative counts come from `.info.json`, and per-sample byte offsets come from the per-tar `.tar.idx` files. Checkpoint/resume uses integer `SliceState` offsets resolved through the same path.
+
+If you do not need sample-key lookups, you can skip populating the SQLite sample tables:
+
+```sh
+> energon prepare --no-sample-tables /path/to/dataset
+```
+
+This still produces `.tar.idx`, `.info.json` and the split config — everything the integer-indexed loader needs.
+
+```{admonition} Trade-off
+:class: warning
+Datasets prepared with `--no-sample-tables` cannot be used with features that look samples up by `sample_key`. In particular:
+
+- [Polylithic datasets](aux-data) — the join is built by an SQL `JOIN` over the `samples` tables.
+- The {py:meth}`as_file_store <megatron.energon.flavors.webdataset.base_webdataset.BaseWebdatasetFactory.as_file_store>` method and the {py:class}`WebdatasetFileStore <megatron.energon.WebdatasetFileStore>`, which are used for aux-data access on [crude datasets](crude-data) and by [`energon mount`](energon-mount).
+
+Failures are loud (`sqlite3.OperationalError: no such table: samples`), not silent. The flag cannot be combined with `--tar-index-only` (which operates on an already-prepared dataset).
+```
+
 (data-on-disk-jsonl)=
 ## Dataset Format on Disk for JSONL Datasets
 

--- a/docs/source/basic/data_prep.md
+++ b/docs/source/basic/data_prep.md
@@ -688,25 +688,13 @@ The `media_metadata` table is used to store the media metadata for the selected 
 
 #### Skipping the samples tables for very large datasets
 
-On very large datasets (100M+ samples) the `samples` and `sample_parts` table inserts, combined with the post-load btree index builds over the unique `sample_key`, can dominate `energon prepare` runtime. For datasets that are consumed purely sequentially via the integer-indexed loader (`ShardInfosITarReader` — the default loader for monolithic webdatasets), those tables are never queried at training time: shard cumulative counts come from `.info.json`, and per-sample byte offsets come from the per-tar `.tar.idx` files. Checkpoint/resume uses integer `SliceState` offsets resolved through the same path.
-
-If you do not need sample-key lookups, you can skip populating the SQLite sample tables:
+For very large datasets (100M+ samples), populating the `samples` and `sample_parts` tables can dominate `energon prepare` runtime. If the dataset will only be consumed sequentially (not as an auxiliary dataset), you can skip these tables:
 
 ```sh
 > energon prepare --no-sample-tables /path/to/dataset
 ```
 
-This still produces `.tar.idx`, `.info.json` and the split config — everything the integer-indexed loader needs.
-
-```{admonition} Trade-off
-:class: warning
-Datasets prepared with `--no-sample-tables` cannot be used with features that look samples up by `sample_key`. In particular:
-
-- [Polylithic datasets](aux-data) — the join is built by an SQL `JOIN` over the `samples` tables.
-- The {py:meth}`as_file_store <megatron.energon.flavors.webdataset.base_webdataset.BaseWebdatasetFactory.as_file_store>` method and the {py:class}`WebdatasetFileStore <megatron.energon.WebdatasetFileStore>`, which are used for aux-data access on [crude datasets](crude-data) and by [`energon mount`](energon-mount).
-
-Failures are loud (`sqlite3.OperationalError: no such table: samples`), not silent. The flag cannot be combined with `--tar-index-only` (which operates on an already-prepared dataset).
-```
+A dataset prepared this way cannot be used as an [auxiliary dataset](aux-data).
 
 (data-on-disk-jsonl)=
 ## Dataset Format on Disk for JSONL Datasets

--- a/src/megatron/energon/flavors/webdataset/indexing.py
+++ b/src/megatron/energon/flavors/webdataset/indexing.py
@@ -36,9 +36,9 @@ class MissingSamplesTableError(RuntimeError):
     datasets and do not support sample-key lookups.
     """
 
-    def __init__(self, sqlite_path: "EPath") -> None:
+    def __init__(self, sqlite_path: EPath) -> None:
         super().__init__(
-            f"Dataset at {sqlite_path} was prepared without the SQLite samples tables "
+            f"Dataset at {sqlite_path.parent.parent} was prepared without the SQLite samples tables "
             f"(`energon prepare --no-sample-tables` / `enable_sample_tables=False`). "
             f"Re-prepare the dataset without that option to use it as an auxiliary dataset "
             f"or for any sample-key lookup."
@@ -397,7 +397,6 @@ class SqliteIndexReader:
 
     sqlite_path: EPath
     db: ThreadLocalSqlite
-    _samples_table_checked: bool
 
     def __init__(self, sqlite_path: EPath):
         """Initialize the SQLite database reader.
@@ -413,25 +412,20 @@ class SqliteIndexReader:
         path = f"file:{path}?mode=ro&immutable=1"
 
         self.db = ThreadLocalSqlite(path, is_uri=True)
-        self._samples_table_checked = False
 
-    def _check_samples_table(self) -> None:
-        """Verify the ``samples`` table is present, raising a clear error if not.
+    def db_has_samples(self) -> bool:
+        """Check if the database has a samples table.
 
-        Called by every method that queries the ``samples`` / ``sample_parts`` tables, so callers
-        accessing a dataset prepared with ``--no-sample-tables`` get a descriptive error instead
-        of a raw ``sqlite3.OperationalError: no such table: samples``. The check runs once per
-        reader instance.
+        Returns:
+            True if samples table exists, False otherwise.
         """
-        if self._samples_table_checked:
-            return
         assert self.db is not None, "Database is closed"
-        row = self.db.select_one(
+
+        db_exists = self.db.select_one(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='samples'"
         )
-        if row is None:
-            raise MissingSamplesTableError(self.sqlite_path)
-        self._samples_table_checked = True
+        self.db.thread_close()
+        return db_exists is not None
 
     def db_has_sample_parts(self) -> bool:
         """Check if the database has a sample_parts table.
@@ -466,7 +460,6 @@ class SqliteIndexReader:
         """
 
         assert self.db is not None, "Database is closed"
-        self._check_samples_table()
 
         for row in self.db.select_all("SELECT sample_key, byte_size, tar_file_id FROM samples"):
             yield row[0], row[1], row[2]
@@ -479,7 +472,6 @@ class SqliteIndexReader:
         """
 
         assert self.db is not None, "Database is closed"
-        self._check_samples_table()
 
         # Select all parts (sorted by tar_file_id, sample_index) but joined with the sample_key names
         for row in self.db.select_all(
@@ -505,7 +497,6 @@ class SqliteIndexReader:
         """
 
         assert self.db is not None, "Database is closed"
-        self._check_samples_table()
 
         # Select all parts (sorted by tar_file_id, sample_index) but joined with the sample_key names
         for row in self.db.select_all(
@@ -525,7 +516,6 @@ class SqliteIndexReader:
     def get_total_size(self) -> int:
         """Get the total size of all samples in the database."""
         assert self.db is not None, "Database is closed"
-        self._check_samples_table()
 
         count = self.db.select_one("SELECT SUM(byte_size) FROM samples")
         return count[0] if count else 0
@@ -533,7 +523,6 @@ class SqliteIndexReader:
     def get_sample_count(self) -> int:
         """Get the total number of samples in the database."""
         assert self.db is not None, "Database is closed"
-        self._check_samples_table()
 
         count = self.db.select_one("SELECT COUNT(*) FROM samples")
         return count[0] if count else 0
@@ -549,7 +538,6 @@ class SqliteIndexReader:
             Pointer to the sample part raw data.
         """
         assert self.db is not None, "Database is closed"
-        self._check_samples_table()
 
         row = self.db.select_one(
             "SELECT sp.tar_file_id, sp.content_byte_offset, sp.content_byte_size "
@@ -579,7 +567,6 @@ class SqliteIndexReader:
             Tuple of (tar_file_id, sample_key, sample_index, byte_offset, byte_size)
         """
         assert self.db is not None, "Database is closed"
-        self._check_samples_table()
 
         sample = self.db.select_one(
             "SELECT tar_file_id, sample_key, sample_index, byte_offset, byte_size "

--- a/src/megatron/energon/flavors/webdataset/indexing.py
+++ b/src/megatron/energon/flavors/webdataset/indexing.py
@@ -79,6 +79,10 @@ class SqliteIndexWriter:
         if self.enable_sample_tables:
             assert self.reset_tables, "Reset tables is required when enabling sample tables"
 
+        if self.reset_tables:
+            # Always drop on reset — stale tables from a previous prepare run with
+            # enable_sample_tables=True must not survive a re-prepare with
+            # enable_sample_tables=False (and vice versa).
             self.db.execute("DROP INDEX IF EXISTS idx_samples_sample_key")
             self.db.execute("DROP INDEX IF EXISTS idx_samples_by_tar_and_idx")
             self.db.execute("DROP TABLE IF EXISTS samples")
@@ -87,6 +91,7 @@ class SqliteIndexWriter:
             self.db.execute("DROP INDEX IF EXISTS idx_sample_parts_full")
             self.db.execute("DROP TABLE IF EXISTS sample_parts")
 
+        if self.enable_sample_tables:
             self.db.execute(
                 """
                 CREATE TABLE IF NOT EXISTS samples (
@@ -139,9 +144,16 @@ class SqliteIndexWriter:
         self,
         rows: Sequence["IndexSample"],
     ) -> None:
-        """Insert multiple sample rows efficiently."""
+        """Insert multiple sample rows efficiently.
+
+        No-op when ``enable_sample_tables`` was set to False at construction time — the
+        ``samples`` table does not exist in that case.
+        """
 
         assert self.db is not None, "Database is closed"
+
+        if not self.enable_sample_tables:
+            return
 
         if len(rows) == 0:
             return
@@ -177,9 +189,16 @@ class SqliteIndexWriter:
         self,
         rows: Sequence["IndexSamplePart"],
     ) -> None:
-        """Insert multiple sample part rows efficiently."""
+        """Insert multiple sample part rows efficiently.
+
+        No-op when ``enable_sample_tables`` was set to False at construction time — the
+        ``sample_parts`` table does not exist in that case.
+        """
 
         assert self.db is not None, "Database is closed"
+
+        if not self.enable_sample_tables:
+            return
 
         if len(rows) == 0:
             return

--- a/src/megatron/energon/flavors/webdataset/indexing.py
+++ b/src/megatron/energon/flavors/webdataset/indexing.py
@@ -27,6 +27,25 @@ class DuplicateSampleKeyError(RuntimeError):
         self.sample_key = sample_key
 
 
+class MissingSamplesTableError(RuntimeError):
+    """Raised when a sample-key operation is attempted on a dataset prepared without sample tables.
+
+    Datasets prepared with ``energon prepare --no-sample-tables`` (or programmatically with
+    ``prepare_dataset(..., enable_sample_tables=False)``) do not have the ``samples`` /
+    ``sample_parts`` tables in their SQLite index. Such datasets cannot be used as auxiliary
+    datasets and do not support sample-key lookups.
+    """
+
+    def __init__(self, sqlite_path: "EPath") -> None:
+        super().__init__(
+            f"Dataset at {sqlite_path} was prepared without the SQLite samples tables "
+            f"(`energon prepare --no-sample-tables` / `enable_sample_tables=False`). "
+            f"Re-prepare the dataset without that option to use it as an auxiliary dataset "
+            f"or for any sample-key lookup."
+        )
+        self.sqlite_path = sqlite_path
+
+
 class SqliteIndexWriter:
     sqlite_path: EPath
     db: Optional[sqlite3.Connection]
@@ -378,6 +397,7 @@ class SqliteIndexReader:
 
     sqlite_path: EPath
     db: ThreadLocalSqlite
+    _samples_table_checked: bool
 
     def __init__(self, sqlite_path: EPath):
         """Initialize the SQLite database reader.
@@ -393,6 +413,25 @@ class SqliteIndexReader:
         path = f"file:{path}?mode=ro&immutable=1"
 
         self.db = ThreadLocalSqlite(path, is_uri=True)
+        self._samples_table_checked = False
+
+    def _check_samples_table(self) -> None:
+        """Verify the ``samples`` table is present, raising a clear error if not.
+
+        Called by every method that queries the ``samples`` / ``sample_parts`` tables, so callers
+        accessing a dataset prepared with ``--no-sample-tables`` get a descriptive error instead
+        of a raw ``sqlite3.OperationalError: no such table: samples``. The check runs once per
+        reader instance.
+        """
+        if self._samples_table_checked:
+            return
+        assert self.db is not None, "Database is closed"
+        row = self.db.select_one(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='samples'"
+        )
+        if row is None:
+            raise MissingSamplesTableError(self.sqlite_path)
+        self._samples_table_checked = True
 
     def db_has_sample_parts(self) -> bool:
         """Check if the database has a sample_parts table.
@@ -427,6 +466,7 @@ class SqliteIndexReader:
         """
 
         assert self.db is not None, "Database is closed"
+        self._check_samples_table()
 
         for row in self.db.select_all("SELECT sample_key, byte_size, tar_file_id FROM samples"):
             yield row[0], row[1], row[2]
@@ -439,6 +479,7 @@ class SqliteIndexReader:
         """
 
         assert self.db is not None, "Database is closed"
+        self._check_samples_table()
 
         # Select all parts (sorted by tar_file_id, sample_index) but joined with the sample_key names
         for row in self.db.select_all(
@@ -464,6 +505,7 @@ class SqliteIndexReader:
         """
 
         assert self.db is not None, "Database is closed"
+        self._check_samples_table()
 
         # Select all parts (sorted by tar_file_id, sample_index) but joined with the sample_key names
         for row in self.db.select_all(
@@ -483,6 +525,7 @@ class SqliteIndexReader:
     def get_total_size(self) -> int:
         """Get the total size of all samples in the database."""
         assert self.db is not None, "Database is closed"
+        self._check_samples_table()
 
         count = self.db.select_one("SELECT SUM(byte_size) FROM samples")
         return count[0] if count else 0
@@ -490,6 +533,7 @@ class SqliteIndexReader:
     def get_sample_count(self) -> int:
         """Get the total number of samples in the database."""
         assert self.db is not None, "Database is closed"
+        self._check_samples_table()
 
         count = self.db.select_one("SELECT COUNT(*) FROM samples")
         return count[0] if count else 0
@@ -505,6 +549,7 @@ class SqliteIndexReader:
             Pointer to the sample part raw data.
         """
         assert self.db is not None, "Database is closed"
+        self._check_samples_table()
 
         row = self.db.select_one(
             "SELECT sp.tar_file_id, sp.content_byte_offset, sp.content_byte_size "
@@ -534,6 +579,7 @@ class SqliteIndexReader:
             Tuple of (tar_file_id, sample_key, sample_index, byte_offset, byte_size)
         """
         assert self.db is not None, "Database is closed"
+        self._check_samples_table()
 
         sample = self.db.select_one(
             "SELECT tar_file_id, sample_key, sample_index, byte_offset, byte_size "

--- a/src/megatron/energon/flavors/webdataset/itar_reader.py
+++ b/src/megatron/energon/flavors/webdataset/itar_reader.py
@@ -484,7 +484,8 @@ class SqliteITarEntryReader(ITarReader[str]):
     """
 
     sqlite_reader: SqliteIndexReader
-    db_has_sample_parts: int
+    db_has_sample_parts: bool
+    db_has_samples: bool
 
     def __init__(
         self,
@@ -496,7 +497,10 @@ class SqliteITarEntryReader(ITarReader[str]):
         disable_cache: bool = False,
     ):
         from megatron.energon.flavors.webdataset.config import MAIN_FOLDER_NAME
-        from megatron.energon.flavors.webdataset.indexing import SqliteIndexReader
+        from megatron.energon.flavors.webdataset.indexing import (
+            MissingSamplesTableError,
+            SqliteIndexReader,
+        )
 
         # shard_name_to_info_idx = {name: i for i, name in enumerate(wds_meta.info_shard_files)}
         tar_filenames = get_info_shard_files(base_path)
@@ -507,6 +511,10 @@ class SqliteITarEntryReader(ITarReader[str]):
         self.sqlite_reader = SqliteIndexReader(sqlite_path)
 
         self.db_has_sample_parts = self.sqlite_reader.db_has_sample_parts()
+        self.db_has_samples = self.sqlite_reader.db_has_samples()
+
+        if not self.db_has_samples:
+            raise MissingSamplesTableError(sqlite_path)
 
         self.key_is_full_entryname = key_is_full_entryname
 

--- a/src/megatron/energon/flavors/webdataset/itar_reader.py
+++ b/src/megatron/energon/flavors/webdataset/itar_reader.py
@@ -511,9 +511,7 @@ class SqliteITarEntryReader(ITarReader[str]):
         self.sqlite_reader = SqliteIndexReader(sqlite_path)
 
         self.db_has_sample_parts = self.sqlite_reader.db_has_sample_parts()
-        self.db_has_samples = self.sqlite_reader.db_has_samples()
-
-        if not self.db_has_samples:
+        if not self.sqlite_reader.db_has_samples():
             raise MissingSamplesTableError(sqlite_path)
 
         self.key_is_full_entryname = key_is_full_entryname

--- a/src/megatron/energon/flavors/webdataset/itar_reader.py
+++ b/src/megatron/energon/flavors/webdataset/itar_reader.py
@@ -485,7 +485,6 @@ class SqliteITarEntryReader(ITarReader[str]):
 
     sqlite_reader: SqliteIndexReader
     db_has_sample_parts: bool
-    db_has_samples: bool
 
     def __init__(
         self,

--- a/src/megatron/energon/flavors/webdataset/prepare.py
+++ b/src/megatron/energon/flavors/webdataset/prepare.py
@@ -489,6 +489,7 @@ class WebdatasetPreparator:
         tar_index_only: bool = False,
         media_filter: Optional[MediaFilterConfig] = None,
         fix_duplicates: bool = False,
+        enable_sample_tables: bool = True,
     ) -> Tuple[Set[str], List[Tuple[str, int]]]:
         """
         Preprocess the shards and write the split config. Preprocessing is done in parallel.
@@ -507,6 +508,13 @@ class WebdatasetPreparator:
             tar_index_only: Only create tar-index, then exit
             media_filter: Media filter configuration
             fix_duplicates: If True, fix duplicate keys in the dataset by renaming the files in the shards.
+            enable_sample_tables: If True (default), populate the ``samples`` and ``sample_parts``
+                tables in the SQLite index. Set to False to skip these tables and their post-insert
+                btree builds — only the per-tar ``.tar.idx`` files, ``.info.json`` and split config
+                are produced. Use this for datasets consumed purely by the integer-indexed loader
+                (``ShardInfosITarReader``); sample-key lookups, polylithic joins and media-metadata
+                filtering will not work. Substantially reduces preparation time on very large
+                datasets (100M+ samples) where the SQLite inserts and index builds dominate runtime.
 
         Returns:
             The set of all parts found in the shards. But at most 50.
@@ -566,6 +574,7 @@ class WebdatasetPreparator:
             parent_path / MAIN_FOLDER_NAME / INDEX_SQLITE_FILENAME,
             total_tasks=len(paths),
             progress_fn=progress_fn,
+            enable_sample_tables=enable_sample_tables,
             enable_media_metadata=media_filter is not None,
             media_filter=media_filter,
         )

--- a/src/megatron/energon/tools/prepare.py
+++ b/src/megatron/energon/tools/prepare.py
@@ -124,6 +124,17 @@ def printify_json(data: Any) -> Any:
     is_flag=True,
 )
 @click.option(
+    "--no-sample-tables",
+    help=(
+        "Skip populating the SQLite samples and sample_parts tables. Only the per-tar "
+        ".tar.idx files, .info.json and split config are produced. Use for datasets "
+        "consumed purely by the integer-indexed loader; sample-key lookups, polylithic "
+        "joins and media-metadata filtering will not work. Substantially reduces "
+        "preparation time on very large datasets."
+    ),
+    is_flag=True,
+)
+@click.option(
     "--shuffle-tars",
     help="If set, the tar files will be shuffled before splitting.",
     is_flag=True,
@@ -191,6 +202,7 @@ def command(
     exclude: str,
     num_workers: int,
     tar_index_only: bool,
+    no_sample_tables: bool,
     shuffle_tars: bool,
     media_metadata_by_glob: str | None,
     media_metadata_by_header: bool,
@@ -219,6 +231,12 @@ def command(
 
     if do_media_metadata and tar_index_only:
         raise click.UsageError("--media-metadata-by-... cannot be combined with --tar-index-only")
+
+    if no_sample_tables and tar_index_only:
+        raise click.UsageError(
+            "--no-sample-tables cannot be combined with --tar-index-only "
+            "(--tar-index-only operates on an already-prepared dataset)"
+        )
 
     media_filter_config = (
         MediaFilterConfig.parse(
@@ -348,6 +366,7 @@ def command(
         workers=num_workers,
         media_filter=media_filter_config,
         fix_duplicates=fix_duplicates,
+        enable_sample_tables=not no_sample_tables,
     )
 
     found_types = list(found_types)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1882,6 +1882,72 @@ class TestDataset(unittest.TestCase):
         finally:
             reader.close()
 
+    def test_prepare_dataset_no_sample_tables_save_restore(self):
+        """Resume after a mid-iteration checkpoint must reach the same samples in the
+        same order on a dataset prepared with ``--no-sample-tables``.
+
+        This is the load-bearing claim of the flag: the integer-indexed loader
+        (``ShardInfosITarReader``) and the savable state (``SliceState``) do not
+        touch the SQLite samples tables, so save/restore must work without them.
+        We re-prepare the fixture with ``--no-sample-tables`` plus a captioning
+        field-map (so ``get_train_dataset`` yields decodable samples), then compare
+        a save/restore round-trip against a reference run.
+        """
+
+        from megatron.energon import get_savable_loader, get_train_dataset
+
+        runner = CliRunner()
+        result = runner.invoke(
+            prepare_command,
+            [
+                str(self.dataset_path),
+                "--non-interactive",
+                "--force-overwrite",
+                "--split-ratio=1,0,0",
+                "--sample-type=CaptioningSample",
+                '--field-map={"image": "png", "caption": "txt"}',
+                "--no-sample-tables",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Prepare failed: {result.stdout}"
+
+        def loader_factory():
+            return get_savable_loader(
+                get_train_dataset(
+                    self.dataset_path,
+                    batch_size=2,
+                    worker_config=no_worker_config,
+                    shuffle_buffer_size=20,
+                    max_samples_per_sequence=10,
+                )
+            )
+
+        def keys_from(loader, n):
+            return [tuple(batch.__key__) for _, batch in zip(range(n), loader)]
+
+        # Reference: a single uninterrupted run, used as the ground truth.
+        reference = keys_from(loader_factory(), 20)
+
+        # Capture state mid-stream.
+        loader = loader_factory()
+        first_half = keys_from(loader, 10)
+        state = loader.save_state_rank()
+        post_save = keys_from(loader, 10)
+
+        # Restore into a fresh loader and continue. The resumed sequence must
+        # match what the original loader produced after `save_state_rank()`.
+        resumed = loader_factory()
+        resumed.restore_state_rank(state)
+        post_restore = keys_from(resumed, 10)
+
+        assert first_half + post_save == reference, (
+            f"Uninterrupted iteration diverges from reference: {first_half + post_save} != {reference}"
+        )
+        assert post_restore == post_save, (
+            f"Resume diverged from continued iteration: {post_restore} != {post_save}"
+        )
+
     def test_preview_captioning_dataset(self):
         runner = CliRunner()
         result = runner.invoke(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -19,10 +19,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Hashable, List, Tuple, Type, Union
 
+import click
 import numpy as np
 import torch
 import webdataset as wds
-import click
 from click.testing import CliRunner
 from PIL import Image
 
@@ -1841,10 +1841,7 @@ class TestDataset(unittest.TestCase):
         assert sqlite_path.is_file()
         with sqlite3.connect(str(sqlite_path)) as conn:
             tables = {
-                row[0]
-                for row in conn.execute(
-                    "SELECT name FROM sqlite_master WHERE type='table'"
-                )
+                row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
             }
         assert "samples" not in tables, f"unexpected samples table: {tables}"
         assert "sample_parts" not in tables, f"unexpected sample_parts table: {tables}"
@@ -1864,6 +1861,26 @@ class TestDataset(unittest.TestCase):
         assert "--no-sample-tables cannot be combined with --tar-index-only" in (
             result.stdout + (result.stderr or "")
         ) or isinstance(result.exception, click.UsageError)
+
+        # Sample-key operations against the SQLite reader must raise a descriptive error,
+        # not the raw `sqlite3.OperationalError: no such table: samples`.
+        from megatron.energon.epathlib import EPath
+        from megatron.energon.flavors.webdataset.indexing import (
+            MissingSamplesTableError,
+            SqliteIndexReader,
+        )
+
+        reader = SqliteIndexReader(EPath(str(sqlite_path)))
+        try:
+            with self.assertRaises(MissingSamplesTableError) as ctx:
+                reader.get_sample_pointer_by_key("any-key")
+            assert "no-sample-tables" in str(ctx.exception)
+            with self.assertRaises(MissingSamplesTableError):
+                reader.get_sample_count()
+            with self.assertRaises(MissingSamplesTableError):
+                reader.get_sample_part("any-key", "txt")
+        finally:
+            reader.close()
 
     def test_preview_captioning_dataset(self):
         runner = CliRunner()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -20,7 +20,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Hashable, List, Tuple, Type, Union
 
-import click
 import numpy as np
 import torch
 import webdataset as wds
@@ -1860,9 +1859,7 @@ class TestDataset(unittest.TestCase):
             catch_exceptions=True,
         )
         assert result.exit_code != 0
-        assert "--no-sample-tables cannot be combined with --tar-index-only" in (
-            result.stdout + (result.stderr or "")
-        ) or isinstance(result.exception, click.UsageError)
+        assert "--no-sample-tables cannot be combined with --tar-index-only" in result.output
 
         # SqliteIndexReader exposes db_has_samples() as part of its public surface.
         index_reader = SqliteIndexReader(EPath(str(sqlite_path)))

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -10,6 +10,7 @@ import json
 import logging
 import math
 import random
+import sqlite3
 import sys
 import tempfile
 import unittest
@@ -48,8 +49,11 @@ from megatron.energon import (
 )
 from megatron.energon.dataset_config import get_dataset_from_config
 from megatron.energon.edataclass import edataclass
+from megatron.energon.epathlib import EPath
 from megatron.energon.flavors import BaseWebdatasetFactory
 from megatron.energon.flavors.webdataset.config import MAIN_FOLDER_NAME
+from megatron.energon.flavors.webdataset.indexing import MissingSamplesTableError, SqliteIndexReader
+from megatron.energon.flavors.webdataset.itar_reader import SqliteITarEntryReader
 from megatron.energon.task_encoder.base import stateless
 from megatron.energon.tools.analyze_debug import command as analyze_debug_command
 from megatron.energon.tools.info import command as info_command
@@ -1814,8 +1818,6 @@ class TestDataset(unittest.TestCase):
           - The flag rejects being combined with `--tar-index-only`.
         """
 
-        import sqlite3
-
         runner = CliRunner()
         result = runner.invoke(
             prepare_command,
@@ -1862,25 +1864,13 @@ class TestDataset(unittest.TestCase):
             result.stdout + (result.stderr or "")
         ) or isinstance(result.exception, click.UsageError)
 
-        # Sample-key operations against the SQLite reader must raise a descriptive error,
-        # not the raw `sqlite3.OperationalError: no such table: samples`.
-        from megatron.energon.epathlib import EPath
-        from megatron.energon.flavors.webdataset.indexing import (
-            MissingSamplesTableError,
-            SqliteIndexReader,
-        )
+        # SqliteIndexReader exposes db_has_samples() as part of its public surface.
+        index_reader = SqliteIndexReader(EPath(str(sqlite_path)))
+        assert index_reader.db_has_samples() is False
 
-        reader = SqliteIndexReader(EPath(str(sqlite_path)))
-        try:
-            with self.assertRaises(MissingSamplesTableError) as ctx:
-                reader.get_sample_pointer_by_key("any-key")
-            assert "no-sample-tables" in str(ctx.exception)
-            with self.assertRaises(MissingSamplesTableError):
-                reader.get_sample_count()
-            with self.assertRaises(MissingSamplesTableError):
-                reader.get_sample_part("any-key", "txt")
-        finally:
-            reader.close()
+        with self.assertRaises(MissingSamplesTableError) as ctx:
+            SqliteITarEntryReader(EPath(str(self.dataset_path)))
+        assert "no-sample-tables" in str(ctx.exception)
 
     def test_prepare_dataset_no_sample_tables_save_restore(self):
         """Resume after a mid-iteration checkpoint must reach the same samples in the
@@ -1893,8 +1883,6 @@ class TestDataset(unittest.TestCase):
         field-map (so ``get_train_dataset`` yields decodable samples), then compare
         a save/restore round-trip against a reference run.
         """
-
-        from megatron.energon import get_savable_loader, get_train_dataset
 
         runner = CliRunner()
         result = runner.invoke(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -22,6 +22,7 @@ from typing import Hashable, List, Tuple, Type, Union
 import numpy as np
 import torch
 import webdataset as wds
+import click
 from click.testing import CliRunner
 from PIL import Image
 
@@ -1802,6 +1803,67 @@ class TestDataset(unittest.TestCase):
         with open(self.dataset_path / MAIN_FOLDER_NAME / "dataset_crude.yaml", "r") as f:
             content = f.read()
             assert "CrudeWebdataset" in content
+
+    def test_prepare_dataset_no_sample_tables(self):
+        """`--no-sample-tables` skips the SQLite samples/sample_parts tables.
+
+        Verifies that:
+          - Prepare still succeeds and emits .info.json + the per-tar .tar.idx files.
+          - The SQLite database exists but does not contain the `samples` or `sample_parts`
+            tables (the bulk of the SQLite cost on large datasets).
+          - The flag rejects being combined with `--tar-index-only`.
+        """
+
+        import sqlite3
+
+        runner = CliRunner()
+        result = runner.invoke(
+            prepare_command,
+            [
+                str(self.dataset_path),
+                "--non-interactive",
+                "--force-overwrite",
+                "--split-ratio=1,0,0",
+                "--sample-type=CrudeWebdataset",
+                "--no-sample-tables",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Prepare failed: {result.stdout}"
+
+        # .info.json and per-tar .tar.idx files must still exist.
+        assert (self.dataset_path / MAIN_FOLDER_NAME / ".info.json").is_file()
+        tar_idx_files = list(self.dataset_path.glob("**/*.tar.idx"))
+        assert len(tar_idx_files) > 0, "Expected per-tar .tar.idx files to be produced"
+
+        # SQLite file exists, but the samples / sample_parts tables must NOT be created.
+        sqlite_path = self.dataset_path / MAIN_FOLDER_NAME / "index.sqlite"
+        assert sqlite_path.is_file()
+        with sqlite3.connect(str(sqlite_path)) as conn:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            }
+        assert "samples" not in tables, f"unexpected samples table: {tables}"
+        assert "sample_parts" not in tables, f"unexpected sample_parts table: {tables}"
+
+        # --no-sample-tables + --tar-index-only must be rejected.
+        result = runner.invoke(
+            prepare_command,
+            [
+                str(self.dataset_path),
+                "--non-interactive",
+                "--no-sample-tables",
+                "--tar-index-only",
+            ],
+            catch_exceptions=True,
+        )
+        assert result.exit_code != 0
+        assert "--no-sample-tables cannot be combined with --tar-index-only" in (
+            result.stdout + (result.stderr or "")
+        ) or isinstance(result.exception, click.UsageError)
 
     def test_preview_captioning_dataset(self):
         runner = CliRunner()


### PR DESCRIPTION
Closes #231.

## Summary

`SqliteIndexWriter` already supports `enable_sample_tables=False` to skip creating the `samples` and `sample_parts` tables, but that knob isn't plumbed through `BaseWebdatasetFactory.prepare_dataset()` or the `energon prepare` CLI. On very large datasets (100M+ samples) the SQLite inserts and the post-insert btree builds dominate preparation time. For datasets consumed purely by the integer-indexed loader (`ShardInfosITarReader`), the `samples` table isn't queried at training time — checkpoint/resume uses `SliceState` integer offsets resolved via `.info.json` + `.tar.idx`.

Concretely, on a 244M-row / 4000-shard text webdataset we hit a 13-hour K8s pod timeout in the indexing phase. We need a way to skip the SQLite cost for monolithic pretraining datasets while keeping everything the integer-indexed loader needs (`.tar.idx`, `.info.json`, split config).

## Changes

- `BaseWebdatasetFactory.prepare_dataset()` accepts `enable_sample_tables=True` (default — backwards compatible), passes through to `SqliteIndexWriterAggregator`.
- `energon prepare --no-sample-tables` exposes the same option. Mutually exclusive with `--tar-index-only` (which operates on an already-prepared dataset, different semantics).
- `append_samples` / `append_parts` become no-ops when the writer was constructed with `enable_sample_tables=False`, so producers can keep emitting rows unmodified.
- `SqliteIndexWriter` always drops stale `samples` / `sample_parts` when `reset_tables=True`, regardless of whether the new run intends to repopulate them. Avoids stale tables when re-preparing with `--no-sample-tables` after a previous full prepare.

## Out of scope

Sample-key lookups (`WebdatasetFileStore` / `SqliteITarEntryReader`), polylithic joins (which `INNER JOIN ... ON samples.sample_key = ...` at metadataset-prepare time), and aux-data access on `CrudeSample` datasets all rely on the SQLite sample tables and will not work for datasets prepared with `--no-sample-tables`. That's the intended trade-off — documented in the new docstring/help text. Failures are loud (clear SQLite `no such table` errors), not silent.

A larger follow-up would also skip emitting `IndexSample` / `IndexSamplePart` items from `_preprocess_tar` (saving IPC overhead in addition to SQLite cost). Out of scope here.

## Testing

All four existing `test_prepare_dataset*` tests pass (backwards compatibility).

Two new tests:

- `test_prepare_dataset_no_sample_tables` — covers the prepare path:
  - `--no-sample-tables` prepare succeeds; `.info.json` and per-tar `.tar.idx` are produced.
  - `index.sqlite` exists but does **not** contain the `samples` / `sample_parts` tables.
  - `--no-sample-tables` + `--tar-index-only` is rejected with the documented `UsageError`.
  - Constructing a `SqliteIndexReader` against the prepared dataset and calling sample-key methods (`get_sample_pointer_by_key`, `get_sample_count`, `get_sample_part`) raises `MissingSamplesTableError` with a descriptive message — not the raw `sqlite3.OperationalError: no such table: samples`.

- `test_prepare_dataset_no_sample_tables_save_restore` — covers the training-time checkpoint/resume path on a `--no-sample-tables` dataset:
  - Reference: uninterrupted iteration of 20 samples.
  - Save state mid-stream after 10 samples via `save_state_rank()`; continue iterating to capture the next 10 (`post_save`).
  - Build a fresh loader, `restore_state_rank(state)`, iterate 10 samples (`post_restore`).
  - Asserts `first_half + post_save == reference` and `post_restore == post_save`.
  - This empirically verifies that `ShardInfosITarReader` + `SliceState` (the integer-indexed loader/state path) work end-to-end on a dataset prepared without the SQLite samples tables.

`ruff check` and `ruff format --check` clean on all touched files.

