### PR TITLE
Implement logical workers

### DIFF
--- a/src/megatron/energon/__init__.py
+++ b/src/megatron/energon/__init__.py
@@ -62,6 +62,7 @@ from megatron.energon.flavors import (
     VQAWebdataset,
 )
 from megatron.energon.loader import get_loader, get_savable_loader
+from megatron.energon.logical_worker import LogicalWorkerAssignment
 from megatron.energon.metadataset import (
     DatasetLoader,
     DatasetLoaderInterface,
@@ -88,6 +89,7 @@ from megatron.energon.task_encoder import (
     get_train_dataset,
     get_val_dataset,
     get_val_datasets,
+    skip_safe,
     stateless,
 )
 from megatron.energon.worker import WorkerConfig
@@ -198,6 +200,7 @@ __all__ = [
     "SkipSample",
     "SourceInfo",
     "StandardWebdatasetFactory",
+    "skip_safe",
     "stateless",
     "SystemFileStore",
     "TaskEncoder",
@@ -209,4 +212,5 @@ __all__ = [
     "VQASample",
     "VQAWebdataset",
     "WorkerConfig",
+    "LogicalWorkerAssignment",
 ]

--- a/src/megatron/energon/errors.py
+++ b/src/megatron/energon/errors.py
@@ -98,6 +98,8 @@ class ErrorContext:
     def handle_errors(
         self,
         sample: Any,
+        *,
+        skip_safe: bool = False,
     ) -> Generator[None, None, None]:
         """Context manager for handling exceptions during sample processing.
 
@@ -119,6 +121,11 @@ class ErrorContext:
                 sample, f"{self.name} failed due to system exception: {e}."
             )
         except Exception as e:
+            if skip_safe:
+                raise FatalSampleError.from_sample(
+                    sample,
+                    f"{self.name} failed due to exception, but was marked as skip-safe: {e}.",
+                ) from e
             print(f"Except {e} in {self.name}")
             # Call the error handler if provided
             if self.handler is not None:

--- a/src/megatron/energon/flavors/base_dataset.py
+++ b/src/megatron/energon/flavors/base_dataset.py
@@ -285,6 +285,16 @@ class SavableDataset(IterableDataset[T_sample], Savable, Generic[T_sample], ABC)
         """
         return sum(self.len_worker(i) for i in range(self.worker_config.num_workers or 1))
 
+    @abstractmethod
+    def set_skip_mode(self, active: bool) -> None:
+        """Toggle best-effort fast-forward mode for the next iterator outputs on the active worker.
+
+        Wrappers may use this transient flag to avoid expensive work for outputs
+        that an outer wrapper will discard. Implementations must still advance
+        iterator state as if the output had been produced.
+        """
+        ...
+
     def __len__(self) -> int:
         """Returns the length of the dataset for the current rank. Corresponds to `len_rank`."""
         return self.len_rank()

--- a/src/megatron/energon/flavors/webdataset/sample_loader.py
+++ b/src/megatron/energon/flavors/webdataset/sample_loader.py
@@ -70,6 +70,8 @@ class WebdatasetSampleLoaderDataset(SavableDataset[RawSampleData]):
     _epoch_count: int
     #: The number of samples retrieved in current epoch
     _epoch_sample_count: int
+    #: Whether to skip heavy computations for discarded outputs
+    _skip_mode: bool
 
     _savable_fields = (
         "_worker_rng",
@@ -132,6 +134,7 @@ class WebdatasetSampleLoaderDataset(SavableDataset[RawSampleData]):
         self._sample_count = 0
         self._epoch_count = 0
         self._epoch_sample_count = 0
+        self._skip_mode = False
 
     def ensure_slice_offsets(self) -> None:
         self.worker_config.assert_worker()
@@ -140,6 +143,11 @@ class WebdatasetSampleLoaderDataset(SavableDataset[RawSampleData]):
             self.slice_offsets = self.workers_slice_offsets[self.worker_config.rank_worker_id()]
 
     def _get_sample(self, index: int) -> RawSampleData:
+        if self._skip_mode:
+            return RawSampleData(
+                __restore_key__=("Webdataset", index),
+                data=tuple(None for _ in self.join_readers),
+            )
         return RawSampleData(
             __restore_key__=("Webdataset", index),
             data=tuple(reader[index] for reader in self.join_readers),
@@ -362,22 +370,36 @@ class WebdatasetSampleLoaderDataset(SavableDataset[RawSampleData]):
                             "probs": active_slice_probs.tolist(),
                         }
                     )
-            if sample.data[0] is not None:
+            if sample.data[0] is not None or self._skip_mode:
                 # Otherwise the sample was skipped.
                 if self.worker_config.should_log(level=1):
-                    self.worker_config.worker_log(
-                        {
-                            "t": "WebdatasetSampleLoaderDataset._slices_iter.yield",
-                            "r": self.worker_config.rank,
-                            "w": self.worker_config.rank_worker_id(),
-                            "index": sample.__restore_key__[1],
-                            "key": sample.data[0]["__key__"],
-                            "shard": sample.data[0]["__shard__"],
-                            "count": self._sample_count,
-                            "epoch": self._epoch_count,
-                            "epoch_count": self._epoch_sample_count,
-                        }
-                    )
+                    if self._skip_mode:
+                        self.worker_config.worker_log(
+                            {
+                                "t": "WebdatasetSampleLoaderDataset._slices_iter.skip",
+                                "r": self.worker_config.rank,
+                                "w": self.worker_config.rank_worker_id(),
+                                "index": sample.__restore_key__[1],
+                                "count": self._sample_count,
+                                "epoch": self._epoch_count,
+                                "epoch_count": self._epoch_sample_count,
+                            }
+                        )
+                    else:
+                        assert sample.data[0] is not None
+                        self.worker_config.worker_log(
+                            {
+                                "t": "WebdatasetSampleLoaderDataset._slices_iter.yield",
+                                "r": self.worker_config.rank,
+                                "w": self.worker_config.rank_worker_id(),
+                                "index": sample.__restore_key__[1],
+                                "key": sample.data[0]["__key__"],
+                                "shard": sample.data[0]["__shard__"],
+                                "count": self._sample_count,
+                                "epoch": self._epoch_count,
+                                "epoch_count": self._epoch_sample_count,
+                            }
+                        )
                 # Now, yield the sample
                 yield sample
                 del sample
@@ -414,6 +436,9 @@ class WebdatasetSampleLoaderDataset(SavableDataset[RawSampleData]):
         self.ensure_slice_offsets()
         assert self.slice_offsets is not None
         return len(self.slice_offsets) > 1
+
+    def set_skip_mode(self, active: bool) -> None:
+        self._skip_mode = active
 
     def __iter__(self) -> Iterator[RawSampleData]:
         self.worker_config.assert_worker()

--- a/src/megatron/energon/flavors/webdataset/sharder.py
+++ b/src/megatron/energon/flavors/webdataset/sharder.py
@@ -195,16 +195,14 @@ class Sharder:
         worker_config: WorkerConfig,
         *,
         rotation_offset: int = 0,
-    ) -> Sequence[int]:
+    ) -> Sequence[Sequence[int]]:
         # We split the total number of samples into the number of global workers across all ranks.
         # Note that the global number of workers intentionally stays the same if you
         # divide the number of ranks by N, and multiply the number of workers per rank by N.
         # This allows to reproduce the same global batches with a different number of ranks.
         total_samples = end_samples - start_samples
 
-        num_workers = max(1, worker_config.num_workers)
-
-        global_workers = num_workers * worker_config.world_size
+        global_workers = worker_config.logical_worker_count()
 
         min_samples_per_worker = int(total_samples / global_workers)
         num_workers_with_more_samples = total_samples % global_workers
@@ -255,16 +253,26 @@ class Sharder:
             cur_offset += num_samples_per_global_worker[global_worker_idx]
             global_worker_sample_split_offsets.append(cur_offset)
 
-        # 4. Now we extract the local rank's worker ranges
-        local_worker_sample_split_offsets = global_worker_sample_split_offsets[
-            worker_config.rank * num_workers : (worker_config.rank + 1) * num_workers + 1
-        ]
-
-        assert len(local_worker_sample_split_offsets) == num_workers + 1, (
-            "If this fails, there's a bug in the code above."
+        # 4. Now we extract the logical worker range served by each physical
+        # worker on this rank. If multiple physical workers share one logical
+        # worker, they intentionally receive the same logical range; an outer
+        # StrideDataset later selects each physical worker's substream.
+        return tuple(
+            (
+                global_worker_sample_split_offsets[
+                    worker_config.logical_assignment_for_physical(
+                        worker_config.physical_global_worker_id(local_worker_idx)
+                    ).logical_global_worker_id
+                ],
+                global_worker_sample_split_offsets[
+                    worker_config.logical_assignment_for_physical(
+                        worker_config.physical_global_worker_id(local_worker_idx)
+                    ).logical_global_worker_id
+                    + 1
+                ],
+            )
+            for local_worker_idx in range(worker_config.physical_workers_per_rank())
         )
-
-        return local_worker_sample_split_offsets
 
     @staticmethod
     def _clean_offsets(offsets: Sequence[int]) -> Sequence[int]:
@@ -342,7 +350,7 @@ class Sharder:
         else:
             start_samples = 0
 
-        local_worker_sample_split_offsets = cls.split_samples_to_workers(
+        local_workers_sample_split_offsets = cls.split_samples_to_workers(
             start_samples,
             end_samples,
             worker_config,
@@ -354,9 +362,10 @@ class Sharder:
         return tuple(
             # Filter out any empty shards for this worker
             cls._clean_offsets(offsets)
+            for worker_offsets in local_workers_sample_split_offsets
             for offsets in cls._split_shards(
                 shard_cumsums,
-                local_worker_sample_split_offsets,
+                worker_offsets,
                 max_samples_per_sequence=max_samples_per_sequence,
             )
         )
@@ -389,7 +398,7 @@ class Sharder:
         """
         start_samples, end_samples = cls._compute_subset(total_samples, subset)
 
-        local_worker_sample_split_offsets = cls.split_samples_to_workers(
+        local_workers_sample_split_offsets = cls.split_samples_to_workers(
             start_samples,
             end_samples,
             worker_config,
@@ -400,8 +409,9 @@ class Sharder:
         return tuple(
             # Filter out any empty shards for this worker
             cls._clean_offsets(offsets)
+            for worker_offsets in local_workers_sample_split_offsets
             for offsets in cls._split_slices(
-                local_worker_sample_split_offsets,
+                worker_offsets,
                 max_samples_per_sequence=max_samples_per_sequence,
             )
         )

--- a/src/megatron/energon/logical_worker.py
+++ b/src/megatron/energon/logical_worker.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class LogicalWorkerAssignment:
+    """How a physical global worker maps onto logical dataset partitions."""
+
+    #: Primary logical global worker id for this physical worker.
+    logical_global_worker_id: int
+    #: Subworker index within the logical stream.
+    stride_offset: int = 0
+    #: Stride between owned output ordinals.
+    stride: int = 1

--- a/src/megatron/energon/savable_loader.py
+++ b/src/megatron/energon/savable_loader.py
@@ -102,7 +102,7 @@ class SimpleSavableDatasetWrapper(BaseWrapperDataset[T, Tuple[int, int, T]], Gen
     def __iter__(self):
         self._state_restored = True
         worker_id = self.worker_config.rank_worker_id()
-        global_worker_id = self.worker_config.global_worker_id()
+        logical_worker_id = self.worker_config.logical_global_worker_id()
         while self._state_restored:
             self._state_restored = False
             self.worker_config.worker_activate(self._sample_index, cache_pool=self.cache_pool)
@@ -113,7 +113,7 @@ class SimpleSavableDatasetWrapper(BaseWrapperDataset[T, Tuple[int, int, T]], Gen
                     worker_active = False
                     sample_index = self._sample_index
                     src_data = add_sample_restore_key(
-                        src_data, global_worker_id, sample_index, src=self
+                        src_data, logical_worker_id, sample_index, src=self
                     )
                     self._sample_index += 1
                     yield worker_id, sample_index, src_data
@@ -129,16 +129,16 @@ class SimpleSavableDatasetWrapper(BaseWrapperDataset[T, Tuple[int, int, T]], Gen
                     self.worker_config.worker_deactivate()
 
     def restore_sample(self, restore_key: Tuple[Union[str, int, tuple], ...]) -> T:
-        id, global_worker_id, sample_idx = restore_key[:3]
+        id, logical_worker_id, sample_idx = restore_key[:3]
         assert id == type(self).__name__
         restore_key = restore_key[3:]
         self.worker_config.worker_activate(
-            sample_idx, override_global_rank=global_worker_id, cache_pool=self.cache_pool
+            sample_idx, override_global_rank=logical_worker_id, cache_pool=self.cache_pool
         )
         try:
             return add_sample_restore_key(
                 self.dataset.restore_sample(restore_key),
-                global_worker_id,
+                logical_worker_id,
                 sample_idx,
                 src=self,
             )
@@ -333,7 +333,7 @@ class SavableDatasetWrapper(IterableDataset[Tuple[int, int, T]], Generic[T]):
         # First: Set the worker offset globally for the current worker
         WorkerConfig.worker_id_offset = self._worker_offset
         self._worker_id = self.worker_config.rank_worker_id()
-        global_worker_id = self.worker_config.global_worker_id()
+        logical_worker_id = self.worker_config.logical_global_worker_id()
         if self._cmd_thread is None:
             self._running = True
             self._command_lock = threading.RLock()
@@ -390,7 +390,7 @@ class SavableDatasetWrapper(IterableDataset[Tuple[int, int, T]], Generic[T]):
                             last_was_skip = False
                             sample_index = self._sample_index
                             add_sample_restore_key(
-                                src_data, global_worker_id, sample_index, src=self
+                                src_data, logical_worker_id, sample_index, src=self
                             )
                             self._sample_index += 1
                             self._store_checkpoint()
@@ -563,14 +563,14 @@ class SavableDatasetWrapper(IterableDataset[Tuple[int, int, T]], Generic[T]):
         return self.dataset.can_restore_sample()
 
     def restore_sample(self, restore_key: Tuple[Union[str, int, tuple], ...]) -> T:
-        id, global_worker_id, sample_idx = restore_key[:3]
+        id, logical_worker_id, sample_idx = restore_key[:3]
         assert id == type(self).__name__
         restore_key = restore_key[3:]
-        self.worker_config.worker_activate(sample_idx, override_global_rank=global_worker_id)
+        self.worker_config.worker_activate(sample_idx, override_global_rank=logical_worker_id)
         try:
             return add_sample_restore_key(
                 self.dataset.restore_sample(restore_key),
-                global_worker_id,
+                logical_worker_id,
                 sample_idx,
                 src=self,
             )

--- a/src/megatron/energon/task_encoder/__init__.py
+++ b/src/megatron/energon/task_encoder/__init__.py
@@ -10,6 +10,7 @@ from megatron.energon.task_encoder.base import (
     batch_pad_stack,
     batch_stack,
     generic_batch,
+    skip_safe,
     stateless,
 )
 from megatron.energon.task_encoder.cooking import Cooker, basic_sample_keys, cooker
@@ -33,6 +34,7 @@ __all__ = [
     "get_train_dataset",
     "get_val_dataset",
     "get_val_datasets",
+    "skip_safe",
     "stateless",
     "TaskEncoder",
 ]

--- a/src/megatron/energon/task_encoder/base.py
+++ b/src/megatron/energon/task_encoder/base.py
@@ -57,6 +57,7 @@ from megatron.energon.wrappers import (
     ShuffleBufferDataset,
 )
 from megatron.energon.wrappers.repeat_dataset import RepeatDataset
+from megatron.energon.wrappers.stride_dataset import maybe_wrap_stride_dataset
 
 T = TypeVar("T")
 V = TypeVar("V")
@@ -123,7 +124,10 @@ P = ParamSpec("P")
 
 @overload
 def stateless(
-    *, restore_seeds: bool = False, failure_tolerance: Optional[int] = None
+    *,
+    restore_seeds: bool = False,
+    failure_tolerance: Optional[int] = None,
+    skip_safe: Optional[bool] = None,
 ) -> Callable[[Callable[P, T]], Callable[P, T]]: ...
 
 
@@ -131,11 +135,28 @@ def stateless(
 def stateless(fn: Callable[P, T]) -> Callable[P, T]: ...
 
 
+@overload
+def stateless(
+    fn: Callable[P, T],
+    *,
+    restore_seeds: bool = False,
+    failure_tolerance: Optional[int] = None,
+    skip_safe: Optional[bool] = None,
+) -> Callable[P, T]: ...
+
+
+def skip_safe(fn: Callable[P, T]) -> Callable[P, T]:
+    """Decorator to mark a task encoder function as safe to elide in skip mode."""
+    setattr(fn, "__skip_safe__", True)
+    return fn
+
+
 def stateless(
     fn: Optional[Callable[..., T]] = None,
     *,
     restore_seeds: bool = False,
     failure_tolerance: Optional[int] = None,
+    skip_safe: Optional[bool] = None,
 ) -> Union[Callable[[Callable[..., T]], Callable[..., T]], Callable[..., T]]:
     """Decorator to mark a function of the task encoder as restorable.
 
@@ -146,6 +167,8 @@ def stateless(
             is restored from that function.
         failure_tolerance: The number of consecutive exceptions that are handled, after which a `FatalSampleError` is
             raised for this function. Set to 0 to disable.
+        skip_safe: Whether this function can be elided while advancing skipped outputs.
+            If omitted, preserves any existing @skip_safe marker.
 
     Usage:
 
@@ -164,7 +187,10 @@ def stateless(
 
     if fn is None:
         return lambda f: stateless(
-            f, restore_seeds=restore_seeds, failure_tolerance=failure_tolerance
+            f,
+            restore_seeds=restore_seeds,
+            failure_tolerance=failure_tolerance,
+            skip_safe=skip_safe,
         )
     if restore_seeds:
         worker_seed = None
@@ -235,12 +261,18 @@ def stateless(
 
         if inspect.isgeneratorfunction(fn):
             setattr(seed_wrapper_generator, "__stateless__", True)
+            if skip_safe is not None:
+                setattr(seed_wrapper_generator, "__skip_safe__", skip_safe)
             return seed_wrapper_generator
         else:
             setattr(seed_wrapper, "__stateless__", True)
+            if skip_safe is not None:
+                setattr(seed_wrapper, "__skip_safe__", skip_safe)
             return seed_wrapper
 
     setattr(fn, "__stateless__", True)
+    if skip_safe is not None:
+        setattr(fn, "__skip_safe__", skip_safe)
     if failure_tolerance is not None:
         setattr(fn, "__failure_tolerance__", failure_tolerance)
     return fn
@@ -249,6 +281,11 @@ def stateless(
 def get_stateless(fn: Callable) -> bool:
     """Get whether a function is stateless."""
     return getattr(fn, "__stateless__", False)
+
+
+def get_skip_safe(fn: Callable) -> bool:
+    """Get whether a function can be elided while advancing skipped outputs."""
+    return getattr(fn, "__skip_safe__", False)
 
 
 def get_failure_tolerance(fn: Callable, default_failure_tolerance: Optional[int] = None) -> int:
@@ -401,6 +438,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
         return not any(getattr(base, func.__name__) is func for base in bases)
 
     @stateless
+    @skip_safe
     def cook_crude_sample(
         self,
         sample: CrudeSample,
@@ -428,6 +466,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
         return cooker.cook(sample, **aux)
 
     @stateless
+    @skip_safe
     def encode_sample(
         self, sample: T_sample
     ) -> Union[T_encoded_sample, Generator[T_encoded_sample, None, None]]:
@@ -438,6 +477,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
         return sample
 
     @stateless
+    @skip_safe
     def preencode_sample(
         self, sample: T_sample
     ) -> Union[T_sample, Generator[T_sample, None, None]]:
@@ -449,6 +489,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
         return sample
 
     @stateless
+    @skip_safe
     def postencode_sample(self, sample: T_sample) -> T_encoded_sample:
         """Post-encode a single sample. May raise :exc:`megatron.energon.SkipSample` to skip a sample.
         Alternatively, this can be a generator that yields (or ignores) new samples.
@@ -458,6 +499,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
         return sample
 
     @stateless
+    @skip_safe
     def batch(self, samples: List[T_encoded_sample]) -> T_raw_batch:
         """Move a batch to a device. May raise :exc:`megatron.energon.SkipSample` to skip a batch."""
         return self._batch(samples, type(samples[0]))
@@ -474,6 +516,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
         return None, None
 
     @stateless
+    @skip_safe
     def encode_batch(self, batch: T_raw_batch) -> Union[T_batch, Generator[T_batch, None, None]]:
         """Encode a batch of samples. May raise :exc:`megatron.energon.SkipSample` to skip a batch.
         Alternatively, this can be a generator that yields (or ignores) new batches."""
@@ -594,10 +637,14 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
                 pre_packer=self.select_samples_to_pack,
                 final_packer=self.pack_selected_samples,
                 final_packer_stateless=get_stateless(self.pack_selected_samples),
+                final_packer_skip_safe=get_skip_safe(self.pack_selected_samples),
                 sample_encoder=post_encode_fn,
                 sample_encoder_stateless=True
                 if post_encode_fn is None
                 else get_stateless(post_encode_fn),
+                sample_encoder_skip_safe=True
+                if post_encode_fn is None
+                else get_skip_safe(post_encode_fn),
                 worker_config=worker_config,
                 pre_packer_failure_tolerance=get_failure_tolerance(
                     self.select_samples_to_pack, self.__default_failure_tolerance__
@@ -615,6 +662,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
                 self.postencode_sample,
                 worker_config=worker_config,
                 stateless_map_fn=get_stateless(self.postencode_sample),
+                map_fn_skip_safe=get_skip_safe(self.postencode_sample),
                 failure_tolerance=get_failure_tolerance(
                     self.postencode_sample, self.__default_failure_tolerance__
                 ),
@@ -639,6 +687,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
                     self.encode_batch,
                     worker_config=worker_config,
                     stateless_map_fn=get_stateless(self.encode_batch),
+                    map_fn_skip_safe=get_skip_safe(self.encode_batch),
                     failure_tolerance=get_failure_tolerance(
                         self.encode_batch, self.__default_failure_tolerance__
                     ),
@@ -652,6 +701,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
                     batch_size=batch_size,
                     batcher=self.batch,
                     batcher_stateless=get_stateless(self.batch),
+                    batcher_skip_safe=get_skip_safe(self.batch),
                     drop_last=batch_drop_last,
                     worker_config=worker_config,
                     failure_tolerance=get_failure_tolerance(
@@ -665,6 +715,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
                         self.encode_batch,
                         worker_config=worker_config,
                         stateless_map_fn=get_stateless(self.encode_batch),
+                        map_fn_skip_safe=get_skip_safe(self.encode_batch),
                         failure_tolerance=get_failure_tolerance(
                             self.encode_batch, self.__default_failure_tolerance__
                         ),
@@ -715,6 +766,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
             cook_fn,
             worker_config=worker_config,
             stateless_map_fn=get_stateless(self.cook_crude_sample),
+            map_fn_skip_safe=get_skip_safe(self.cook_crude_sample),
             map_fn_config=dict(
                 cooker=dict(
                     cook=SavableDataset._function_config(cooker.cook),
@@ -763,6 +815,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
                 pre_encode_fn,
                 worker_config=worker_config,
                 stateless_map_fn=get_stateless(pre_encode_fn),
+                map_fn_skip_safe=get_skip_safe(pre_encode_fn),
                 failure_tolerance=get_failure_tolerance(
                     pre_encode_fn, self.__default_failure_tolerance__
                 ),
@@ -789,7 +842,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
             if isinstance(dataset.dataset, CrudeWebdataset):
                 assert self.cookers, "CrudeWebdataset found, but no cookers registered."
 
-        global_workers = max(1, worker_config.num_workers) * worker_config.world_size
+        global_workers = worker_config.logical_worker_count()
         rotation_lengths = [len(dataset.dataset) for dataset in datasets]
         for i in range(1, len(rotation_lengths)):
             rotation_lengths[i] += rotation_lengths[i - 1]
@@ -882,6 +935,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
             packing_buffer_size=packing_buffer_size,
             worker_config=worker_config,
         )
+        dataset = maybe_wrap_stride_dataset(dataset, worker_config=worker_config)
         if virtual_epoch_length > 0:
             dataset = EpochizeDataset(
                 dataset,
@@ -910,7 +964,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
             if isinstance(dataset, CrudeWebdataset):
                 assert self.cookers, "CrudeWebdataset found, but no cookers registered."
 
-        global_workers = max(1, worker_config.num_workers) * worker_config.world_size
+        global_workers = worker_config.logical_worker_count()
         rotation_lengths = [len(dataset.dataset) for dataset in datasets]
         for i in range(1, len(rotation_lengths)):
             rotation_lengths[i] += rotation_lengths[i - 1]
@@ -938,6 +992,7 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
             packing_buffer_size=packing_buffer_size,
             worker_config=worker_config,
         )
+        dataset = maybe_wrap_stride_dataset(dataset, worker_config=worker_config)
         if limit is not None and limit > 0:
             dataset = LimitDataset(
                 dataset,
@@ -1034,6 +1089,7 @@ class DefaultTaskEncoder(
         self._batch_type = batch_type
 
     @stateless
+    @skip_safe
     def encode_sample(
         self, sample: T_sample
     ) -> Union[T_encoded_sample, Generator[T_encoded_sample, None, None]]:
@@ -1062,6 +1118,7 @@ class DefaultTaskEncoder(
             raise ValueError("Unrecognized encoded sample type.")
 
     @stateless
+    @skip_safe
     def batch(self, samples: List[T_encoded_sample]) -> T_raw_batch:
         """Batch a list of samples. The default implementation uses default batching to convert
         to _batch_type."""
@@ -1077,6 +1134,7 @@ class DefaultTaskEncoder(
         )
 
     @stateless
+    @skip_safe
     def encode_batch(self, batch: T_raw_batch) -> Union[T_batch, Generator[T_batch, None, None]]:
         """Encode a batch of samples. The default implementation converts to the
         _encoded_batch_type."""

--- a/src/megatron/energon/worker.py
+++ b/src/megatron/energon/worker.py
@@ -13,9 +13,10 @@ import torch.utils.data
 
 from megatron.energon.cache import CachePool
 from megatron.energon.errors import log_exception, reraise_exception
+from megatron.energon.logical_worker import LogicalWorkerAssignment
 from megatron.energon.source_info import SourceInfo
 
-__all__ = ("WorkerConfig",)
+__all__ = ("WorkerConfig", "LogicalWorkerAssignment")
 
 T = TypeVar("T")
 
@@ -36,6 +37,10 @@ class WorkerConfig:
     world_size: int
     #: The number of workers per rank. May be 0 to disable worker processes.
     num_workers: int
+
+    #: Global number of logical dataset partitions. Defaults to physical worker count.
+    #: Must be a multiple of, or divide evenly into, physical worker count.
+    logical_workers: Optional[int] = None
 
     #: If not using all ranks for data parallel, set this to the corresponding group.
     data_parallel_group: Optional[torch.distributed.ProcessGroup] = None
@@ -78,10 +83,26 @@ class WorkerConfig:
     active_worker_config: ClassVar[Optional["WorkerConfig"]] = None
 
     #: The global rank override for the worker. Required for restoring samples.
-    _worker_override_global_rank: ClassVar[Optional[List[int]]] = None
+    _worker_override_global_rank: ClassVar[Optional[int]] = None
+
+    #: Active logical global worker id during restore.
+    _active_logical_global_worker_id: ClassVar[Optional[int]] = None
 
     #: The current cache pool for the worker.
     _cache_pool: "ClassVar[Optional[CachePool]]" = None
+
+    def __post_init__(self) -> None:
+        physical = self.physical_worker_count()
+        logical = self.logical_worker_count()
+        if logical > physical:
+            raise ValueError(
+                f"logical_workers ({logical}) must be less than or equal to "
+                f"physical_workers ({physical})"
+            )
+        if physical % logical != 0:
+            raise ValueError(
+                f"physical_workers ({physical}) must be divisible by logical_workers ({logical})"
+            )
 
     def worker_activate(
         self,
@@ -119,6 +140,7 @@ class WorkerConfig:
             WorkerConfig._sample_index_stack = None
             WorkerConfig.active_worker_config = None
             WorkerConfig._worker_override_global_rank = None
+            WorkerConfig._active_logical_global_worker_id = None
 
     @property
     def active_worker_sample_index(self) -> int:
@@ -147,6 +169,67 @@ class WorkerConfig:
 
         return torch.distributed.get_global_rank(self.data_parallel_group, self.rank)
 
+    def physical_workers_per_rank(self) -> int:
+        """PyTorch DataLoader worker processes per rank (0 means main process only)."""
+        return max(1, self.num_workers) if self.num_workers > 0 else 1
+
+    def physical_worker_count(self) -> int:
+        """Total physical workers across all ranks."""
+        if self.num_workers == 0:
+            return self.world_size
+        return self.world_size * self.num_workers
+
+    def logical_worker_count(self) -> int:
+        """Total logical dataset partitions across all ranks."""
+        if self.logical_workers is None:
+            return self.physical_worker_count()
+        return self.logical_workers
+
+    def logical_workers_per_rank(self) -> int:
+        """Logical dataset partitions per rank."""
+        logical = self.logical_worker_count()
+        assert logical % self.world_size == 0, (
+            f"logical_workers ({logical}) must be divisible by world_size ({self.world_size})"
+        )
+        return logical // self.world_size
+
+    def logical_assignment_for_physical(
+        self, physical_global_worker_id: int
+    ) -> LogicalWorkerAssignment:
+        """Map a physical global worker id to logical partition and striding."""
+        physical_count = self.physical_worker_count()
+        logical_count = self.logical_worker_count()
+        assert 0 <= physical_global_worker_id < physical_count
+
+        fanout = physical_count // logical_count
+        logical_id = physical_global_worker_id // fanout
+        return LogicalWorkerAssignment(
+            logical_global_worker_id=logical_id,
+            stride_offset=physical_global_worker_id % fanout,
+            stride=fanout,
+        )
+
+    def assignment_for_current_physical_worker(self) -> LogicalWorkerAssignment:
+        """Logical assignment for the currently active physical worker."""
+        return self.logical_assignment_for_physical(self.physical_global_worker_id())
+
+    def logical_global_worker_id(self, override_local_worker_id: Optional[int] = None) -> int:
+        """Global logical worker id used for dataset splits, RNG, and restore keys."""
+        if WorkerConfig._active_logical_global_worker_id is not None:
+            return WorkerConfig._active_logical_global_worker_id
+        if self._worker_override_global_rank is not None:
+            physical = self._worker_override_global_rank
+        else:
+            physical = self.physical_global_worker_id(override_local_worker_id)
+        return self.logical_assignment_for_physical(physical).logical_global_worker_id
+
+    def logical_local_worker_index(self, override_local_worker_id: Optional[int] = None) -> int:
+        """Logical worker index within the current rank."""
+        return (
+            self.logical_global_worker_id(override_local_worker_id)
+            - self.rank * self.logical_workers_per_rank()
+        )
+
     def __eq__(self, other):
         """Do not compare everything to check for equal config"""
         if not isinstance(other, WorkerConfig):
@@ -156,6 +239,7 @@ class WorkerConfig:
                 self.rank == other.rank,
                 self.world_size == other.world_size,
                 self.num_workers == other.num_workers,
+                self.logical_workers == other.logical_workers,
             ]
         )
 
@@ -208,23 +292,25 @@ class WorkerConfig:
                 f"match the configured number of workers ({self.num_workers})"
             )
 
-    def global_worker_id(self, override_local_worker_id: Optional[int] = None) -> int:
-        """Returns the global worker index by multiplying the rank with the number of workers.
-        Alternatively, you can override the local worker id.
-
-        Args:
-            override_local_worker_id (int, optional): The local worker id to override. None means
-                the current worker, which is the default.
-        """
+    def physical_global_worker_id(self, override_local_worker_id: Optional[int] = None) -> int:
+        """Global physical worker id (PyTorch DataLoader worker slot)."""
         if self._worker_override_global_rank is not None:
             assert override_local_worker_id is None
             return self._worker_override_global_rank
 
+        if self.num_workers == 0:
+            if override_local_worker_id is not None:
+                return self.rank
+            return self.rank
+
         if override_local_worker_id is not None:
             return self.rank * self.num_workers + override_local_worker_id
-        else:
-            self.assert_worker()
-            return self.rank * self.num_workers + self.rank_worker_id()
+        self.assert_worker()
+        return self.rank * self.num_workers + self.rank_worker_id()
+
+    def global_worker_id(self, override_local_worker_id: Optional[int] = None) -> int:
+        """Alias for :meth:`physical_global_worker_id` (DataLoader checkpointing)."""
+        return self.physical_global_worker_id(override_local_worker_id)
 
     def worker_seed(self, override_local_worker_id: Optional[int] = None) -> int:
         """Returns the seed for the current worker (or a specified worker).
@@ -237,11 +323,7 @@ class WorkerConfig:
                 the current worker, which is the default.
         """
 
-        if self.num_workers == 0:
-            # If we are not using workers, different ranks should still get a different seed
-            global_worker_id = self.rank
-        else:
-            global_worker_id = self.global_worker_id(override_local_worker_id)
+        global_worker_id = self.logical_global_worker_id(override_local_worker_id)
 
         seed_offset = self.seed_offset
 
@@ -254,10 +336,16 @@ class WorkerConfig:
             "rank": self.rank,
             "world_size": self.world_size,
             "num_workers": self.num_workers,
+            "logical_workers": self.logical_workers,
             "data_parallel_group": (
                 self.data_parallel_group.size() if self.data_parallel_group else None
             ),
         }
+
+    @staticmethod
+    def set_active_logical_global_worker_id(logical_global_worker_id: Optional[int]) -> None:
+        """Set the logical worker id used while restoring."""
+        WorkerConfig._active_logical_global_worker_id = logical_global_worker_id
 
     def should_log(self, level: int) -> bool:
         return level <= self.worker_log_level

--- a/src/megatron/energon/wrappers/__init__.py
+++ b/src/megatron/energon/wrappers/__init__.py
@@ -22,6 +22,7 @@ from megatron.energon.wrappers.packing_dataset import PackingDataset
 from megatron.energon.wrappers.repeat_dataset import RepeatDataset
 from megatron.energon.wrappers.shuffle_buffer_dataset import ShuffleBufferDataset
 from megatron.energon.wrappers.skip import SkipSample
+from megatron.energon.wrappers.stride_dataset import StrideDataset, maybe_wrap_stride_dataset
 
 __all__ = [
     "BatchDataset",
@@ -39,6 +40,8 @@ __all__ = [
     "RepeatDataset",
     "ShuffleBufferDataset",
     "SkipSample",
+    "StrideDataset",
+    "maybe_wrap_stride_dataset",
     "PackingDataset",
     "concat_pad",
     "generic_concat",

--- a/src/megatron/energon/wrappers/base.py
+++ b/src/megatron/energon/wrappers/base.py
@@ -64,6 +64,10 @@ class BaseWrapperDataset(SavableDataset[T_sample_out], Generic[T_sample_in, T_sa
     def worker_has_samples(self) -> bool:
         return any(ds.worker_has_samples() for ds in self.datasets)
 
+    def set_skip_mode(self, active: bool) -> None:
+        for ds in self.datasets:
+            ds.set_skip_mode(active)
+
     def _find_wrapped_dataset(self, cls: Type[SavableDataset]) -> Optional[SavableDataset]:
         """Find the outermost dataset wrapped in this dataset that is of type cls."""
 
@@ -171,6 +175,10 @@ class SampleIndex(Savable):
         finally:
             if hasattr(it, "close"):
                 it.close()
+
+    def skip(self, n: int = 1) -> None:
+        """Advance the sample index as if ``n`` outputs had been yielded."""
+        self.current_idx += n
 
     def save_state(self) -> int:
         return self.current_idx

--- a/src/megatron/energon/wrappers/batch_dataset.py
+++ b/src/megatron/energon/wrappers/batch_dataset.py
@@ -14,6 +14,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from megatron.energon.errors import ErrorContext, handle_restore_errors
@@ -34,6 +35,7 @@ class BatchDataset(BaseWrapperDataset[T_batch_sample, T_batch], Generic[T_batch_
     _sample_index: SampleIndex
     _generator_sample_keys: Optional[Any]
     _generator_offset: Optional[int]
+    _skip_mode: bool
     _batch_failure_handler: ErrorContext
 
     _savable_fields = ("_sample_index", "_generator_sample_keys", "_generator_offset")
@@ -45,6 +47,7 @@ class BatchDataset(BaseWrapperDataset[T_batch_sample, T_batch], Generic[T_batch_
         batcher: Callable[[List[T_batch_sample]], T_batch],
         *,
         batcher_stateless: bool = False,
+        batcher_skip_safe: bool = False,
         batcher_config: Optional[Union[Dict[str, Any], Callable[[], Dict[str, Any]]]] = None,
         drop_last: bool = False,
         failure_tolerance: int = 100,
@@ -59,6 +62,7 @@ class BatchDataset(BaseWrapperDataset[T_batch_sample, T_batch], Generic[T_batch_
                 :exc:`megatron.energon.SkipSample` to skip a sample.
             batcher_stateless: If True, the batcher is stateless, thus samples can be stored/
                 restored.
+            batcher_skip_safe: If True, the batcher is skip-safe, thus samples can be skipped.
             batcher_config: Configuration for the batcher function. If callable, it should return the
                 configuration. Defaults to None.
             drop_last: If True, the last batch is dropped if it is smaller than the batch size.
@@ -69,6 +73,7 @@ class BatchDataset(BaseWrapperDataset[T_batch_sample, T_batch], Generic[T_batch_
         self.batch_size = batch_size
         self.batcher = batcher
         self.batcher_stateless = batcher_stateless
+        self.batcher_skip_safe = batcher_skip_safe
         self.batcher_config = batcher_config
         self.drop_last = drop_last
         self.failure_tolerance = failure_tolerance
@@ -84,6 +89,7 @@ class BatchDataset(BaseWrapperDataset[T_batch_sample, T_batch], Generic[T_batch_
         self._sample_index = SampleIndex(self.worker_config, src=self)
         self._generator_sample_keys = None
         self._generator_offset = None
+        self._skip_mode = False
 
     def len_worker(self, worker_idx: int | None = None) -> int:
         n_samples = self.dataset.len_worker(worker_idx)
@@ -92,11 +98,18 @@ class BatchDataset(BaseWrapperDataset[T_batch_sample, T_batch], Generic[T_batch_
             n_batches += 1
         return n_batches
 
+    def set_skip_mode(self, active: bool) -> None:
+        """Set whether to skip heavy computations for discarded outputs."""
+        if self.batcher_skip_safe:
+            self.dataset.set_skip_mode(active)
+        self._skip_mode = active
+
     def __iter__(self) -> Iterator[T_batch]:
         batch: List[T_batch_sample] = []
         sample_restore_keys = []
 
         if self._generator_sample_keys is not None:
+            assert not self.batcher_skip_safe, "Batcher is skip-safe but has a generator"
             sample_restore_keys = self._generator_sample_keys
             assert self._generator_offset is not None
             batch = [self.dataset.restore_sample(inner_idx) for inner_idx in sample_restore_keys]
@@ -127,7 +140,12 @@ class BatchDataset(BaseWrapperDataset[T_batch_sample, T_batch], Generic[T_batch_
             sample_restore_keys = []
 
         def flush() -> Generator[T_batch, None, None]:
-            with self._batch_failure_handler.handle_errors(batch):
+            if self._skip_mode and self.batcher_skip_safe:
+                self._sample_index.skip()
+                yield cast(T_batch, None)
+                sample_restore_keys.clear()
+                return
+            with self._batch_failure_handler.handle_errors(batch, skip_safe=self.batcher_skip_safe):
                 with self._sample_index.ctx() as sample_idx:
                     batch_sample = self.batcher(batch)
                 if isinstance(batch_sample, Generator):

--- a/src/megatron/energon/wrappers/map_dataset.py
+++ b/src/megatron/energon/wrappers/map_dataset.py
@@ -13,6 +13,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from megatron.energon.errors import (
@@ -32,10 +33,12 @@ class MapDataset(BaseWrapperDataset[T_sample, T_sample_out], Generic[T_sample, T
 
     map_fn: Callable[[T_sample], Union[T_sample_out, Generator[T_sample_out, None, None]]]
     stateless_map_fn: bool
+    map_fn_skip_safe: bool
     map_fn_config: Optional[Union[Dict[str, Any], Callable[[], Dict[str, Any]]]]
     _sample_index: SampleIndex
     _generator_sample_key: Optional[Any]
     _generator_offset: Optional[int]
+    _skip_mode: bool
     _map_failure_handler: ErrorContext
 
     _savable_fields = (
@@ -50,6 +53,7 @@ class MapDataset(BaseWrapperDataset[T_sample, T_sample_out], Generic[T_sample, T
         map_fn: Callable[[T_sample], Union[T_sample_out, Generator[T_sample_out, None, None]]],
         *,
         stateless_map_fn: bool = False,
+        map_fn_skip_safe: bool = False,
         map_fn_config: Optional[Union[Dict[str, Any], Callable[[], Dict[str, Any]]]] = None,
         failure_tolerance: int = 100,
         worker_config: WorkerConfig,
@@ -74,6 +78,7 @@ class MapDataset(BaseWrapperDataset[T_sample, T_sample_out], Generic[T_sample, T
         super().__init__(dataset, worker_config=worker_config)
         self.map_fn = map_fn
         self.stateless_map_fn = stateless_map_fn
+        self.map_fn_skip_safe = map_fn_skip_safe
         self.map_fn_config = map_fn_config
         self.failure_tolerance = failure_tolerance
         self._map_failure_handler = ErrorContext(
@@ -88,9 +93,17 @@ class MapDataset(BaseWrapperDataset[T_sample, T_sample_out], Generic[T_sample, T
         self._sample_index = SampleIndex(self.worker_config, src=self)
         self._generator_sample_key = None
         self._generator_offset = None
+        self._skip_mode = False
 
     def len_worker(self, worker_idx: int | None = None) -> int:
         return self.dataset.len_worker(worker_idx)
+
+    def set_skip_mode(self, active: bool) -> None:
+        if self.map_fn_skip_safe and not inspect.isgeneratorfunction(self.map_fn):
+            self.dataset.set_skip_mode(active)
+        else:
+            self.dataset.set_skip_mode(False)
+        self._skip_mode = active
 
     def __iter__(self) -> Iterator[T_sample_out]:
         if self._generator_sample_key is not None:
@@ -121,11 +134,20 @@ class MapDataset(BaseWrapperDataset[T_sample, T_sample_out], Generic[T_sample, T
             self._generator_offset = None
 
         for sample in self.dataset:
+            if (
+                self._skip_mode
+                and self.map_fn_skip_safe
+                and not inspect.isgeneratorfunction(self.map_fn)
+            ):
+                self._sample_index.skip(1)
+                yield cast(T_sample_out, None)
+                continue
             restore_key = get_sample_restore_key(sample)
             with self._map_failure_handler.handle_errors(sample):
                 with self._sample_index.ctx() as sample_idx:
                     mapped_sample = self.map_fn(sample)
                 if isinstance(mapped_sample, Generator):
+                    assert not self.map_fn_skip_safe, "Generator in map_fn but skip_mode is active"
                     assert inspect.isgeneratorfunction(self.map_fn), (
                         f"Generator in {self.map_fn} but not marked as such."
                     )

--- a/src/megatron/energon/wrappers/packing_dataset.py
+++ b/src/megatron/energon/wrappers/packing_dataset.py
@@ -14,6 +14,7 @@ from typing import (
     Optional,
     TypeVar,
     Union,
+    cast,
 )
 
 from megatron.energon.errors import ErrorContext, handle_restore_errors
@@ -67,6 +68,7 @@ class PackingDataset(
 
     #: Sample index for the final_packer
     _final_packing_sample_index: SampleIndex
+    _skip_mode: bool
 
     #: Error handlers for tracking failures
     _pre_pack_failure_handler: ErrorContext
@@ -90,8 +92,10 @@ class PackingDataset(
         final_packer: Callable[[List[T_encoded_sample]], T_batch_sample],
         *,
         final_packer_stateless: bool = False,
+        final_packer_skip_safe: bool = False,
         sample_encoder: Optional[Callable[[T_sample], T_encoded_sample]] = None,
         sample_encoder_stateless: bool = False,
+        sample_encoder_skip_safe: bool = False,
         packer_config: Optional[Union[Dict[str, Any], Callable[[], Dict[str, Any]]]] = None,
         pre_packer_failure_tolerance: int = 100,
         final_packer_failure_tolerance: int = 100,
@@ -130,8 +134,10 @@ class PackingDataset(
         self.pre_packer = pre_packer
         self.final_packer = final_packer
         self.final_packer_stateless = final_packer_stateless
+        self.final_packer_skip_safe = final_packer_skip_safe
         self.sample_encoder = sample_encoder
         self.sample_encoder_stateless = True if sample_encoder is None else sample_encoder_stateless
+        self.sample_encoder_skip_safe = True if sample_encoder is None else sample_encoder_skip_safe
         self.packer_config = packer_config
 
         self.pre_packer_failure_tolerance = pre_packer_failure_tolerance
@@ -168,11 +174,16 @@ class PackingDataset(
         self._pre_packing_sample_index = SampleIndex(self.worker_config, src=self)
         self._final_packing_sample_index = SampleIndex(self.worker_config, src=self)
         self._sample_encoder_sample_index = SampleIndex(self.worker_config, src=self)
+        self._skip_mode = False
 
     def len_worker(self, worker_idx: int | None = None) -> int:
         # The real length is unknown, since it depends on the packing function.
         # We approximate it by the length of the source dataset.
         return self.dataset.len_worker(worker_idx)
+
+    def set_skip_mode(self, active: bool) -> None:
+        # Do not pass to inner datasets, because we cannot simplify through the pre_packing step.
+        self._skip_mode = active
 
     def _fill_reading_buffer(self, source_iter: Iterator, log_progress: bool = False) -> bool:
         """
@@ -220,6 +231,9 @@ class PackingDataset(
 
         def encode_pack_samples(pack: List[T_sample]) -> List[T_encoded_sample]:
             """Encode the samples in the pack using the sample encoder."""
+            if self._skip_mode and self.sample_encoder_skip_safe and self.final_packer_skip_safe:
+                self._sample_encoder_sample_index.skip(len(pack))
+                return len(pack) * [None]
 
             # Apply the sample encoder to the pack
             if self.sample_encoder is None:
@@ -276,11 +290,20 @@ class PackingDataset(
 
             del self._pre_packing_buffer[: pre_packing_lengths[0]]
             del pre_packing_lengths[0]
+
+            if self._skip_mode and self.final_packer_skip_safe:
+                self._final_packing_sample_index.skip(1)
+                yield cast(T_batch_sample, None)
+                return
+
             with self._final_pack_failure_handler.handle_errors(pack):
                 pack_restore_keys = tuple(get_sample_restore_key(sample) for sample in pack)
                 with self._final_packing_sample_index.ctx() as pack_idx:
                     final_packed_sample = self.final_packer(pack)
                 if isinstance(final_packed_sample, Generator):
+                    assert not self.final_packer_skip_safe, (
+                        "Generator in final_packer but skip_safe"
+                    )
                     assert inspect.isgeneratorfunction(self.final_packer), (
                         f"Generator in {self.final_packer} but not marked as such."
                     )

--- a/src/megatron/energon/wrappers/stride_dataset.py
+++ b/src/megatron/energon/wrappers/stride_dataset.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from typing import Any, Dict, Generic, Iterator, Optional, TypeVar
+
+from megatron.energon.flavors.base_dataset import SavableDataset
+from megatron.energon.logical_worker import LogicalWorkerAssignment
+from megatron.energon.worker import WorkerConfig
+from megatron.energon.wrappers.base import BaseWrapperDataset
+
+T_sample = TypeVar("T_sample")
+
+
+def _stride_needed(worker_config: WorkerConfig) -> bool:
+    return worker_config.physical_worker_count() > worker_config.logical_worker_count()
+
+
+class StrideDataset(BaseWrapperDataset[T_sample, T_sample], Generic[T_sample]):
+    """Maps physical workers onto logical streams.
+
+    When ``physical_workers > logical_workers``, consumes inner outputs via iteration
+    (including discarded ones) so upstream stages still advance correctly. Discarded
+    outputs are produced under skip mode so skip-safe wrappers can avoid heavy work.
+    """
+
+    _savable_fields = ()
+
+    def __init__(
+        self,
+        dataset: SavableDataset[T_sample],
+        *,
+        worker_config: WorkerConfig,
+        assignment: Optional[LogicalWorkerAssignment] = None,
+    ):
+        super().__init__(dataset, worker_config=worker_config)
+        self._assignment = assignment
+        self.reset_state_own()
+
+    def reset_state_own(self) -> None:
+        pass
+
+    def len_worker(self, worker_idx: int | None = None) -> int:
+        inner_len = self.dataset.len_worker(worker_idx)
+        assignment = self._ensure_assignment()
+        if inner_len <= assignment.stride_offset:
+            return 0
+        return (inner_len - assignment.stride_offset + assignment.stride - 1) // assignment.stride
+
+    def _apply_active_logical_worker(self) -> None:
+        assignment = self._ensure_assignment()
+        WorkerConfig.set_active_logical_global_worker_id(assignment.logical_global_worker_id)
+
+    def _ensure_assignment(self) -> LogicalWorkerAssignment:
+        if self._assignment is None:
+            self._assignment = self.worker_config.assignment_for_current_physical_worker()
+        return self._assignment
+
+    def _skip_inner(
+        self,
+        src_iter: Iterator[T_sample],
+        count: int,
+    ) -> None:
+        for _ in range(count):
+            self.dataset.set_skip_mode(True)
+            try:
+                next(src_iter)
+            except StopIteration:
+                return
+            finally:
+                self.dataset.set_skip_mode(False)
+
+    def __iter__(self) -> Iterator[T_sample]:
+        assignment = self._ensure_assignment()
+
+        self._apply_active_logical_worker()
+        src_iter = iter(self.dataset)
+        try:
+            while True:
+                self._skip_inner(src_iter, assignment.stride_offset)
+                self.dataset.set_skip_mode(False)
+                try:
+                    yield next(src_iter)
+                except StopIteration:
+                    break
+                self._skip_inner(src_iter, assignment.stride - assignment.stride_offset - 1)
+        finally:
+            self.dataset.set_skip_mode(False)
+            WorkerConfig.set_active_logical_global_worker_id(None)
+
+    def worker_has_samples(self) -> bool:
+        return self.dataset.worker_has_samples()
+
+    def config(self) -> Dict[str, Any]:
+        return {
+            "type": type(self).__qualname__,
+            "dataset": self.dataset.config(),
+            "assignment": (
+                None
+                if self._assignment is None
+                else {
+                    "logical_global_worker_id": self._assignment.logical_global_worker_id,
+                    "stride_offset": self._assignment.stride_offset,
+                    "stride": self._assignment.stride,
+                }
+            ),
+            "worker_config": self.worker_config.config(),
+        }
+
+    def __str__(self) -> str:
+        return f"StrideDataset(dataset={self.dataset})"
+
+
+def maybe_wrap_stride_dataset(
+    dataset: SavableDataset[T_sample],
+    *,
+    worker_config: WorkerConfig,
+    assignment: Optional[LogicalWorkerAssignment] = None,
+) -> SavableDataset[T_sample]:
+    """Wrap with :class:`StrideDataset` when logical and physical worker counts differ."""
+    if _stride_needed(worker_config) or assignment is not None:
+        return StrideDataset(dataset, worker_config=worker_config, assignment=assignment)
+    return dataset

--- a/tests/test_logical_workers.py
+++ b/tests/test_logical_workers.py
@@ -1,0 +1,409 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import gc
+import logging
+import pickle
+import sys
+import tempfile
+import unittest
+import warnings
+from pathlib import Path
+from typing import List
+
+import torch
+import webdataset as wds
+
+from megatron.energon import (
+    Batch,
+    Cooker,
+    DefaultTaskEncoder,
+    WorkerConfig,
+    basic_sample_keys,
+    cooker,
+    get_savable_loader,
+    get_train_dataset,
+    skip_safe,
+    stateless,
+)
+from megatron.energon.edataclass import edataclass
+from megatron.energon.flavors.base_dataset import Sample
+from megatron.energon.flavors.webdataset.config import MAIN_FOLDER_NAME
+from megatron.energon.logical_worker import LogicalWorkerAssignment
+from megatron.energon.wrappers.stride_dataset import _stride_needed
+
+try:
+    torch.utils.data._utils.worker.MP_STATUS_CHECK_INTERVAL = 0.1
+    torch.utils.data._utils.MP_STATUS_CHECK_INTERVAL = 0.1
+except AttributeError:
+    pass
+
+
+@edataclass
+class IndexTextSample(Sample):
+    index: int
+    text: str
+
+
+@edataclass
+class IndexTextBatch(Batch):
+    indexes: list[int]
+
+
+@cooker()
+@stateless
+def cook_index_sample(sample: dict) -> IndexTextSample:
+    idx = int(sample["txt"])
+    return IndexTextSample(
+        **basic_sample_keys(sample),
+        index=idx,
+        text=sample["txt"],
+    )
+
+
+class TestWorkerConfigLogicalWorkers(unittest.TestCase):
+    def test_default_logical_equals_physical(self) -> None:
+        wc = WorkerConfig(rank=0, world_size=2, num_workers=4)
+        assert wc.physical_worker_count() == 8
+        assert wc.logical_worker_count() == 8
+        assert wc.logical_workers_per_rank() == 4
+
+    def test_physical_gt_logical_assignment(self) -> None:
+        wc = WorkerConfig(rank=0, world_size=1, num_workers=4, logical_workers=2)
+        assert wc.physical_worker_count() == 4
+        assert wc.logical_worker_count() == 2
+        a0 = wc.logical_assignment_for_physical(0)
+        assert a0 == LogicalWorkerAssignment(logical_global_worker_id=0, stride_offset=0, stride=2)
+        a1 = wc.logical_assignment_for_physical(1)
+        assert a1 == LogicalWorkerAssignment(logical_global_worker_id=0, stride_offset=1, stride=2)
+
+    def test_logical_gt_physical_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            WorkerConfig(rank=0, world_size=1, num_workers=2, logical_workers=4)
+
+    def test_invalid_multiple_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            WorkerConfig(rank=0, world_size=1, num_workers=5, logical_workers=3)
+
+    def test_stride_needed(self) -> None:
+        wc = WorkerConfig(rank=0, world_size=1, num_workers=4, logical_workers=2)
+        assert _stride_needed(wc)
+        wc2 = WorkerConfig(rank=0, world_size=1, num_workers=2)
+        assert not _stride_needed(wc2)
+
+
+class TrackingCrudePackingTaskEncoder(
+    DefaultTaskEncoder[IndexTextSample, IndexTextSample, IndexTextBatch, IndexTextBatch]
+):
+    """Crude webdataset encoder with pre/post encode, packing (2), and batching (3)."""
+
+    cookers = [Cooker(cook_index_sample, has_subflavors={"crude_type": "index"})]
+
+    def __init__(self) -> None:
+        super().__init__(raw_batch_type=IndexTextBatch, batch_type=IndexTextBatch)
+
+        self.pre_indexes: List[int] = []
+        self.post_indexes: List[int] = []
+        self.select_buffer_indexes: List[int] = []
+        self.pack_group_indexes: List[List[int]] = []
+        self.batch_packed_indexes: List[int] = []
+
+    @stateless
+    def preencode_sample(self, sample: IndexTextSample) -> IndexTextSample:
+        self.pre_indexes.append(sample.index)
+        return sample
+
+    @stateless
+    @skip_safe
+    def postencode_sample(self, sample: IndexTextSample) -> IndexTextSample:
+        self.post_indexes.append(sample.index)
+        return sample
+
+    def select_samples_to_pack(self, samples: List[IndexTextSample]) -> List[List[IndexTextSample]]:
+        self.select_buffer_indexes.extend([s.index for s in samples])
+        return [samples[i : i + 2] for i in range(0, len(samples), 2)]
+
+    @stateless
+    @skip_safe
+    def pack_selected_samples(self, pack: List[IndexTextSample]) -> IndexTextBatch:
+        indexes = [s.index for s in pack]
+        self.pack_group_indexes.append(indexes)
+        return IndexTextBatch.from_samples(
+            pack,
+            indexes=indexes,
+        )
+
+    @stateless
+    @skip_safe
+    def batch(self, samples: List[IndexTextBatch]) -> IndexTextBatch:
+        indexes = []
+        for s in samples:
+            indexes.extend(s.indexes)
+        self.batch_packed_indexes.extend(indexes)
+        return IndexTextBatch.from_samples(
+            samples,
+            indexes=indexes,
+        )
+
+
+class TrackingCrudePackingPostPackNotSkipSafeTaskEncoder(TrackingCrudePackingTaskEncoder):
+    """Same pipeline, but post/pack are not marked skip-safe."""
+
+    @stateless
+    def postencode_sample(self, sample: IndexTextSample) -> IndexTextSample:
+        self.post_indexes.append(sample.index)
+        return sample
+
+    @stateless
+    def pack_selected_samples(self, pack: List[IndexTextSample]) -> IndexTextBatch:
+        indexes = [s.index for s in pack]
+        self.pack_group_indexes.append(indexes)
+        return IndexTextBatch.from_samples(
+            pack,
+            indexes=indexes,
+        )
+
+    @stateless(skip_safe=True)
+    def batch(self, samples: List[IndexTextBatch]) -> IndexTextBatch:
+        indexes = []
+        for s in samples:
+            indexes.extend(s.indexes)
+        self.batch_packed_indexes.extend(indexes)
+        return IndexTextBatch.from_samples(
+            samples,
+            indexes=indexes,
+        )
+
+
+class TestLogicalWorkerCrudeE2E(unittest.TestCase):
+    NUM_SAMPLES = 60
+
+    @staticmethod
+    def create_index_crude_dataset(path: Path, offset: int, count: int) -> None:
+        """Creates a small crude webdataset with numeric txt/pkl indices (see test_crudedataset)."""
+        from megatron.energon.flavors import BaseWebdatasetFactory
+
+        (path / "parts").mkdir(exist_ok=True, parents=True)
+
+        with wds.ShardWriter(f"{path}/parts/data-%d.tar", maxcount=count) as shard_writer:
+            for idx in range(count):
+                value = idx + offset
+                shard_writer.write(
+                    {
+                        "__key__": f"{value:06d}",
+                        "txt": f"{value}".encode(),
+                        "pkl": pickle.dumps({"idx": value}),
+                    },
+                )
+            total_shards = shard_writer.shard
+
+        BaseWebdatasetFactory.prepare_dataset(
+            path,
+            [f"parts/data-{{0..{total_shards - 1}}}.tar"],
+            split_parts_ratio=[("train", 1.0)],
+            shuffle_seed=None,
+            workers=1,
+            media_filter=None,
+        )
+
+        with open(path / MAIN_FOLDER_NAME / "dataset.yaml", "w") as f:
+            f.write(
+                "\n".join(
+                    [
+                        "__module__: megatron.energon",
+                        "__class__: CrudeWebdataset",
+                        "subflavors:",
+                        "  crude_type: index",
+                    ]
+                )
+            )
+
+    def setUp(self) -> None:
+        logging.basicConfig(stream=sys.stderr, level=logging.INFO)
+        warnings.simplefilter("ignore", ResourceWarning)
+
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.dataset_path = Path(self.temp_dir.name)
+        self.dataset_path.mkdir(exist_ok=True, parents=True)
+
+        self.create_index_crude_dataset(
+            self.dataset_path / "ds",
+            offset=0,
+            count=self.NUM_SAMPLES,
+        )
+
+        self.ds_path = self.dataset_path / "ds"
+
+    def tearDown(self) -> None:
+        gc.collect()
+        self.temp_dir.cleanup()
+
+    def test_pre_on_all_post_and_pack_on_strided_physical_worker(self) -> None:
+        """E2E: crude webdataset, real TaskEncoder pipeline.
+
+        Models rank=0, world_size=6, num_workers=0, logical_workers=2 (6 physical, fanout 3):
+        all 60 samples are loaded on rank 0 (world_size=1 for the test loader), and an
+        explicit stride assignment for physical worker 0 yields indices 0, 3, 6, ...
+
+        Pre-encode must run on every sample; post-encode, pack (2), and batch (3) only
+        on the strided subset.
+        """
+        # Load all samples on rank 0 (no DataLoader subprocesses — stats stay in-process).
+        wc = WorkerConfig(rank=0, world_size=2, num_workers=0, logical_workers=2)
+
+        orig_te = TrackingCrudePackingTaskEncoder()
+
+        orig_loader = get_savable_loader(
+            get_train_dataset(
+                str(self.ds_path),
+                task_encoder=orig_te,
+                worker_config=wc,
+                batch_size=3,
+                packing_buffer_size=self.NUM_SAMPLES // 4,
+                shuffle_buffer_size=None,
+                max_samples_per_sequence=4,
+                repeat=False,
+            )
+        )
+
+        orig_samples = list(orig_loader)
+        print(f"orig_samples: {[batch.indexes for batch in orig_samples]}")
+
+        # Models rank=0 with world_size=6, num_workers=0, logical_workers=2 (6 physical, fanout 3).
+        stride1_wc = WorkerConfig(rank=0, world_size=6, num_workers=0, logical_workers=2)
+        te1 = TrackingCrudePackingTaskEncoder()
+        stride1_loader = get_savable_loader(
+            get_train_dataset(
+                str(self.ds_path),
+                task_encoder=te1,
+                worker_config=stride1_wc,
+                batch_size=3,
+                packing_buffer_size=self.NUM_SAMPLES // 4,
+                shuffle_buffer_size=None,
+                max_samples_per_sequence=4,
+                repeat=False,
+            )
+        )
+        stride1_samples = list(stride1_loader)
+        print(f"stride1 samples: {[batch.indexes for batch in stride1_samples]}")
+
+        # Models rank=1 with world_size=6, num_workers=0, logical_workers=2 (6 physical, fanout 3).
+        stride2_wc = WorkerConfig(rank=1, world_size=6, num_workers=0, logical_workers=2)
+        te2 = TrackingCrudePackingTaskEncoder()
+        stride2_loader = get_savable_loader(
+            get_train_dataset(
+                str(self.ds_path),
+                task_encoder=te2,
+                worker_config=stride2_wc,
+                batch_size=3,
+                packing_buffer_size=self.NUM_SAMPLES // 4,
+                shuffle_buffer_size=None,
+                max_samples_per_sequence=4,
+                repeat=False,
+            )
+        )
+        stride2_samples = list(stride2_loader)
+        print(f"stride2_samples: {[batch.indexes for batch in stride2_samples]}")
+
+        # Models rank=2 with world_size=6, num_workers=0, logical_workers=2 (6 physical, fanout 3).
+        stride3_wc = WorkerConfig(rank=2, world_size=6, num_workers=0, logical_workers=2)
+        te3 = TrackingCrudePackingTaskEncoder()
+        stride3_loader = get_savable_loader(
+            get_train_dataset(
+                str(self.ds_path),
+                task_encoder=te3,
+                worker_config=stride3_wc,
+                batch_size=3,
+                packing_buffer_size=self.NUM_SAMPLES // 4,
+                shuffle_buffer_size=None,
+                max_samples_per_sequence=4,
+                repeat=False,
+            )
+        )
+        stride3_samples = list(stride3_loader)
+        print(f"stride3_samples: {[batch.indexes for batch in stride3_samples]}")
+
+        # Combining the samples from ranks 0-2 should give the same samples as the original loader.
+        # It should be precisely interleaved.
+        strided_samples = [stride1_samples, stride2_samples, stride3_samples]
+        strided_encoders = [te1, te2, te3]
+        interleaved_stride_samples = [sample for group in zip(*strided_samples) for sample in group]
+        print(
+            f"interleaved_stride_samples: {[batch.indexes for batch in interleaved_stride_samples]}"
+        )
+
+        assert [batch.indexes for batch in interleaved_stride_samples] == [
+            batch.indexes for batch in orig_samples
+        ]
+
+        for stride_offset, (stride_samples, te) in enumerate(
+            zip(strided_samples, strided_encoders)
+        ):
+            expected_stride_samples = orig_samples[stride_offset::3]
+            expected_stride_indexes = [
+                index for batch in expected_stride_samples for index in batch.indexes
+            ]
+            print(f"stride_samples[{stride_offset}]: {[batch.indexes for batch in stride_samples]}")
+            print(f"expected_stride_indexes[{stride_offset}]: {expected_stride_indexes}")
+            assert [batch.indexes for batch in stride_samples] == [
+                batch.indexes for batch in expected_stride_samples
+            ]
+            assert te.pre_indexes == orig_te.pre_indexes
+            assert te.select_buffer_indexes == orig_te.select_buffer_indexes
+            print(f"stride_samples[{stride_offset}]: {te.post_indexes}")
+            print(f"expected_stride_indexes[{stride_offset}]: {expected_stride_indexes}")
+            assert te.post_indexes == expected_stride_indexes
+            assert [
+                index for pack in te.pack_group_indexes for index in pack
+            ] == expected_stride_indexes
+            assert te.batch_packed_indexes == expected_stride_indexes
+
+    def test_non_skip_safe_post_pack_run_on_skipped_outputs(self) -> None:
+        """E2E: non-skip-safe post/pack still run for discarded physical outputs."""
+        wc = WorkerConfig(rank=0, world_size=2, num_workers=0, logical_workers=2)
+
+        orig_te = TrackingCrudePackingPostPackNotSkipSafeTaskEncoder()
+        orig_loader = get_savable_loader(
+            get_train_dataset(
+                str(self.ds_path),
+                task_encoder=orig_te,
+                worker_config=wc,
+                batch_size=3,
+                packing_buffer_size=self.NUM_SAMPLES // 4,
+                shuffle_buffer_size=None,
+                max_samples_per_sequence=4,
+                repeat=False,
+            )
+        )
+        orig_samples = list(orig_loader)
+
+        stride_wc = WorkerConfig(rank=0, world_size=6, num_workers=0, logical_workers=2)
+        te = TrackingCrudePackingPostPackNotSkipSafeTaskEncoder()
+        stride_loader = get_savable_loader(
+            get_train_dataset(
+                str(self.ds_path),
+                task_encoder=te,
+                worker_config=stride_wc,
+                batch_size=3,
+                packing_buffer_size=self.NUM_SAMPLES // 4,
+                shuffle_buffer_size=None,
+                max_samples_per_sequence=4,
+                repeat=False,
+            )
+        )
+        stride_samples = list(stride_loader)
+
+        expected_stride_samples = orig_samples[::3]
+        expected_all_indexes = [index for batch in orig_samples for index in batch.indexes]
+        expected_stride_indexes = [
+            index for batch in expected_stride_samples for index in batch.indexes
+        ]
+
+        assert [batch.indexes for batch in stride_samples] == [
+            batch.indexes for batch in expected_stride_samples
+        ]
+        assert te.pre_indexes == orig_te.pre_indexes
+        assert te.select_buffer_indexes == orig_te.select_buffer_indexes
+        assert te.post_indexes == expected_all_indexes
+        assert [index for pack in te.pack_group_indexes for index in pack] == expected_all_indexes
+        assert te.batch_packed_indexes == expected_stride_indexes

--- a/tests/test_metadataset.py
+++ b/tests/test_metadataset.py
@@ -752,6 +752,7 @@ class TestDataset(unittest.TestCase):
             "rank": 0,
             "world_size": 1,
             "num_workers": 0,
+            "logical_workers": None,
             "data_parallel_group": None,
         }
         print("loader.config():")


### PR DESCRIPTION
* Allow setting `logical_workers` in the `WorkerConfig`. This number may be less than the number of physical workers (=`world_size * num_workers`), but physical workers must be divisible by logical workers.
* Default: `logical_workers = physical_workers` (old behavior)
* Example: Setting `logical_workers = physical_workers / 4` would result in 4 physical workers iterating the same data, but each with a stride of 4
  * For optimization, one may set `@skip_safe` or `@stateless(skip_safe=True)` on functions in the `TaskEncoder`, resulting in not calling these functions when skipping samples (if the chain supports it).
  * Only functions without fanout and that do not raise errors (to be caught) may be marked as `skip_safe`.
  * Cannot go "through" packing or filtering (there are non-precomputable (i.e. without reading the sample) fanouts in these).