### PR TITLE
Implement dynamic blending

### DIFF
--- a/src/megatron/energon/task_encoder/base.py
+++ b/src/megatron/energon/task_encoder/base.py
@@ -373,6 +373,9 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
     #: The decoder to use for decoding samples. Set manually as needed to override options.
     decoder: Optional[SampleDecoder] = SampleDecoder()
 
+    blend_sample_size_alpha: float = 1.0
+    blend_sample_size_epsilon: float = 1.0
+
     def _is_overridden(
         self, bound_method: Callable[..., Any], bases: Optional[Sequence[Type[Any]]] = None
     ) -> bool:
@@ -456,6 +459,15 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
         If this is defined, :func:`encode_sample` must not be defined.
         """
         return sample
+
+    @stateless
+    def blend_sample_size(self, sample: T_sample) -> int | float:
+        """Return the blend accounting size of a sample.
+
+        When overridden, :class:`BlendDataset` uses soft size-deficit regulation so blend weights
+        target accumulated size rather than sample count. Default is 1 (sample-count blending).
+        """
+        return 1.0
 
     @stateless
     def batch(self, samples: List[T_encoded_sample]) -> T_raw_batch:
@@ -857,9 +869,15 @@ class TaskEncoder(ABC, Generic[T_sample, T_encoded_sample, T_raw_batch, T_batch]
         if len(inner_datasets) > 1:
             # The worker offset for each dataset is the cumsum of the dataset lengths, but modulo the
             # global number of workers.
+            sample_size_fn = (
+                self.blend_sample_size if self._is_overridden(self.blend_sample_size) else None
+            )
             dataset = BlendDataset(
                 *[inner_dataset[:2] for inner_dataset in inner_datasets],
                 worker_config=worker_config,
+                sample_size_fn=sample_size_fn,
+                sample_size_epsilon=self.blend_sample_size_epsilon,
+                sample_size_alpha=self.blend_sample_size_alpha,
             )
         elif len(datasets) == 1:
             dataset = inner_datasets[0][0]

--- a/src/megatron/energon/wrappers/blend_dataset.py
+++ b/src/megatron/energon/wrappers/blend_dataset.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from typing import Any, Dict, Iterator, List, Sequence, Tuple, TypeVar
+from typing import Any, Callable, Dict, Iterator, Sequence, Tuple, TypeVar
 
 import torch
 
@@ -19,18 +19,25 @@ class BlendDataset(BaseWrapperDataset[T_sample, T_sample]):
     The datasets may be infinite. This dataset is always infinite.
     """
 
-    datasets: List[SavableDataset[T_sample]]
-    weights: Tuple[float, ...]
-    dataset_weights: Sequence[Tuple[SavableDataset[T_sample], float]]
-    exhausted: List[bool]
+    datasets: tuple[SavableDataset[T_sample], ...]
+    weights: tuple[float, ...]
+    dataset_weights: Sequence[tuple[SavableDataset[T_sample], float]]
+    exhausted: list[bool]
     _worker_rng: WorkerRng
+    sample_size_fn: Callable[[T_sample], int | float] | None
+    sample_size_alpha: float
+    sample_size_epsilon: float
+    _emitted_sizes: list[float]
 
-    _savable_fields = ("exhausted", "_worker_rng")
+    _savable_fields = ("exhausted", "_worker_rng", "_emitted_sizes")
 
     def __init__(
         self,
         *dataset_weights: Tuple[SavableDataset[T_sample], float],
         worker_config: WorkerConfig,
+        sample_size_fn: Callable[[T_sample], int | float] | None = None,
+        sample_size_alpha: float = 1.0,
+        sample_size_epsilon: float = 1.0,
     ):
         """Construct a BlendDataset.
 
@@ -39,22 +46,45 @@ class BlendDataset(BaseWrapperDataset[T_sample, T_sample]):
                 between 0 and 1. The output samples are sampled from the input datasets with the
                 given probabilities.
             worker_config: Configuration for the workers.
+            sample_size_fn: Optional function returning the accounting size of a sample. When set,
+                sampling uses soft size-deficit regulation toward the target weight distribution.
+            sample_size_alpha: Exponent for size-deficit credits. Higher values favor datasets
+                furthest behind their target size share.
+            sample_size_epsilon: Floor added to credits so every active dataset keeps non-zero
+                selection probability.
         """
-        # datasets = [dataset for dataset, _weight in dataset_weights]
         self.datasets, self.weights = zip(*dataset_weights)
 
         super().__init__(self.datasets, worker_config=worker_config)
 
         self.dataset_weights = dataset_weights
+        self.sample_size_fn = sample_size_fn
+        self.sample_size_alpha = sample_size_alpha
+        self.sample_size_epsilon = sample_size_epsilon
         self.reset_state_own()
 
     def reset_state_own(self) -> None:
         self._worker_rng = WorkerRng(self.worker_config)
-        self.exhausted = [False] * len(self.weights)
+        n = len(self.weights)
+        self.exhausted = [False] * n
+        self._emitted_sizes = [0.0] * n
 
     def len_worker(self, worker_idx: int | None = None) -> int:
         # Give the number of samples in inner datasets, disregarding the weight
         return sum(dataset.len_worker(worker_idx) for dataset in self.datasets)
+
+    def _compute_size_probs(
+        self,
+        weights: torch.Tensor,
+        emitted: torch.Tensor,
+    ) -> torch.Tensor:
+        target_weights = weights / weights.sum()
+        deficits = target_weights * emitted.sum() - emitted
+        credits = torch.clamp(deficits, min=0.0)
+        probs = target_weights * (self.sample_size_epsilon + credits) ** self.sample_size_alpha
+        if probs.sum() == 0:
+            probs = weights
+        return probs
 
     def __iter__(self) -> Iterator[T_sample]:
         assert self.worker_has_samples(), "Cannot blend all empty datasets"
@@ -62,20 +92,20 @@ class BlendDataset(BaseWrapperDataset[T_sample, T_sample]):
         # Create a list of datasets and their weights, but
         # set the weight to 0 if the dataset has no samples on this worker.
 
-        dataset_iters = []
-        weights = []
+        dataset_iters: list[Iterator[T_sample] | None] = []
+        weights_list: list[float] = []
         for idx, (dataset, weight) in enumerate(self.dataset_weights):
             assert weight > 0, "All blending weights must be > 0"
 
             if dataset.worker_has_samples():
                 dataset_iters.append(iter(dataset))
-                weights.append(weight)
+                weights_list.append(weight)
             else:
                 dataset_iters.append(None)
-                weights.append(0)
+                weights_list.append(0)
                 self.exhausted[idx] = True
 
-        weights = torch.tensor(weights, dtype=torch.float32)
+        weights = torch.tensor(weights_list, dtype=torch.float32)
         if weights.sum() == 0:
             raise RuntimeError(
                 "There is a worker with no samples in any of the blended datasets. "
@@ -89,15 +119,24 @@ class BlendDataset(BaseWrapperDataset[T_sample, T_sample]):
                 weights[idx] = 0
                 dataset_iters[idx] = None
 
-        while True:
-            ds_idx = self._worker_rng.choice_idx(probs=weights)
+        if self.sample_size_fn is not None:
+            emitted = torch.tensor(self._emitted_sizes, dtype=torch.float64)
 
-            if dataset_iters[ds_idx] is None:
+        while True:
+            if self.sample_size_fn is None:
+                ds_probs = weights
+            else:
+                ds_probs = self._compute_size_probs(weights, emitted)
+
+            ds_idx = self._worker_rng.choice_idx(probs=ds_probs)
+
+            dataset_iter = dataset_iters[ds_idx]
+            if dataset_iter is None:
                 if all(dataset_iter is None for dataset_iter in dataset_iters):
                     break
                 continue
             try:
-                sample = next(dataset_iters[ds_idx])
+                sample = next(dataset_iter)
             except StopIteration:
                 dataset_iters[ds_idx] = None
                 weights[ds_idx] = 0
@@ -105,18 +144,28 @@ class BlendDataset(BaseWrapperDataset[T_sample, T_sample]):
                 if all(dataset_iter is None for dataset_iter in dataset_iters):
                     break
             else:
+                if self.sample_size_fn is not None:
+                    size = float(self.sample_size_fn(sample))
+                    assert size >= 0, "sample_size_fn must return a non-negative value"
+                    self._emitted_sizes[ds_idx] += size
+                    emitted[ds_idx] += size
                 yield add_sample_restore_key(sample, ds_idx, src=self)
 
         self.exhausted = [False] * len(self.dataset_weights)
 
     def config(self) -> Dict[str, Any]:
-        return {
+        cfg: Dict[str, Any] = {
             "type": type(self).__qualname__,
             "dataset_weights": [
                 (dataset.config(), weight) for dataset, weight in self.dataset_weights
             ],
             "worker_config": self.worker_config.config(),
         }
+        if self.sample_size_fn is not None:
+            cfg["sample_size_fn"] = self._function_config(self.sample_size_fn)
+            cfg["sample_size_alpha"] = self.sample_size_alpha
+            cfg["sample_size_epsilon"] = self.sample_size_epsilon
+        return cfg
 
     def __str__(self):
         return f"BlendDataset(dataset_weights={self.dataset_weights})"

--- a/tests/test_metadataset_v2.py
+++ b/tests/test_metadataset_v2.py
@@ -32,7 +32,8 @@ from megatron.energon.epathlib.epath import EPath
 from megatron.energon.flavors.webdataset.config import MAIN_FOLDER_NAME
 from megatron.energon.metadataset.loader import prepare_metadataset, traverse_metadataset
 from megatron.energon.metadataset.loader_interface import DatasetBlendMode
-from megatron.energon.task_encoder.base import DefaultTaskEncoder
+from megatron.energon.task_encoder.base import DefaultTaskEncoder, stateless
+from megatron.energon.wrappers.blend_dataset import BlendDataset
 from megatron.energon.wrappers.watchdog_dataset import WatchdogDataset
 from tests.epath_s3_emulator import setup_s3_emulator
 
@@ -79,6 +80,23 @@ class TestJoinedSample(Sample):
 
 def test_joiner(text1: TextSample, text2: TextSample) -> TestJoinedSample:
     return TestJoinedSample.derive_from(text1, text1=f"j{text1.text}", text2=f"j{text2.text}")
+
+
+def get_blend_dataset(ds):
+    if isinstance(ds, BlendDataset):
+        return ds
+    if hasattr(ds, "dataset"):
+        return get_blend_dataset(ds.dataset)
+    raise ValueError("No blend dataset found")
+
+
+class SizeBlendTaskEncoder(DefaultTaskEncoder):
+    blend_sample_size_alpha: float = 0.8
+    blend_sample_size_epsilon: float = 0.7
+
+    @stateless
+    def blend_sample_size(self, sample: TextSample) -> int:
+        return len(sample.text)
 
 
 class TestDataset(unittest.TestCase):
@@ -223,6 +241,42 @@ class TestDataset(unittest.TestCase):
                         "  source: dataset.yaml",
                         "  dataset.yaml: true",
                         "  number: 42",
+                    ]
+                )
+            )
+
+    @staticmethod
+    def create_fixed_size_text_dataset(path: Path, key_range: Iterable[int], text_size: int):
+        """Creates a text dataset where every sample has the same byte length."""
+        (path / "parts").mkdir(exist_ok=True, parents=True)
+        with wds.ShardWriter(f"{path}/parts/data-%d.tar", maxcount=10) as shard_writer:
+            for key in key_range:
+                shard_writer.write(
+                    {
+                        "__key__": f"{key:06d}",
+                        "txt": ("x" * text_size).encode(),
+                    },
+                )
+            total_shards = shard_writer.shard
+
+        from megatron.energon.flavors import BaseWebdatasetFactory
+
+        BaseWebdatasetFactory.prepare_dataset(
+            path,
+            [f"parts/data-{{0..{total_shards - 1}}}.tar"],
+            split_parts_ratio=[("train", 1.0)],
+            shuffle_seed=None,
+        )
+
+        with open(path / MAIN_FOLDER_NAME / "dataset.yaml", "w") as f:
+            f.write(
+                "\n".join(
+                    [
+                        "sample_type:",
+                        "  __module__: megatron.energon",
+                        "  __class__: TextSample",
+                        "field_map:",
+                        "  text: txt",
                     ]
                 )
             )
@@ -1554,6 +1608,157 @@ class TestDataset(unittest.TestCase):
         assert all(sample_counts[sample] == 1 for sample in range(230, 240)), sample_counts
         assert all(sample_counts[sample] == 0 for sample in range(240, 255)), sample_counts
         assert sample_counts.total() == 10 + 9 * 2, sample_counts.total()
+
+    def test_blend_sample_size_based_distribution(self):
+        torch.manual_seed(42)
+        worker_config = WorkerConfig(
+            rank=0,
+            world_size=1,
+            num_workers=0,
+            seed_offset=42,
+        )
+
+        short_size = 2
+        long_size = 50
+        self.create_fixed_size_text_dataset(
+            self.dataset_path / "ds_short", range(55), text_size=short_size
+        )
+        self.create_fixed_size_text_dataset(
+            self.dataset_path / "ds_long", range(100, 155), text_size=long_size
+        )
+
+        size_blend_mds_path = self.dataset_path / "metadataset_size_blend.yaml"
+        with open(size_blend_mds_path, "w") as f:
+            f.write(
+                "\n".join(
+                    [
+                        "__module__: megatron.energon",
+                        "__class__: MetadatasetV2",
+                        "splits:",
+                        "  train:",
+                        "    blend:",
+                        "      - weight: 1",
+                        "        path: ds_short",
+                        "        subflavors:",
+                        "          source: ds_short",
+                        "      - weight: 1",
+                        "        path: ds_long",
+                        "        subflavors:",
+                        "          source: ds_long",
+                    ]
+                )
+            )
+
+        def load_samples(task_encoder: DefaultTaskEncoder, n_samples: int):
+            loader = get_loader(
+                get_train_dataset(
+                    size_blend_mds_path,
+                    worker_config=worker_config,
+                    batch_size=None,
+                    shuffle_buffer_size=None,
+                    max_samples_per_sequence=None,
+                    task_encoder=task_encoder,
+                )
+            )
+            return list(zip(range(n_samples), loader))
+
+        n_samples = 2000
+        default_samples = load_samples(DefaultTaskEncoder(), n_samples)
+        size_samples = load_samples(SizeBlendTaskEncoder(), n_samples)
+
+        def tally(samples):
+            sample_counts: Counter[str] = Counter()
+            size_totals: Counter[str] = Counter()
+            for _, sample in samples:
+                source = sample.__subflavors__["source"]
+                sample_counts[source] += 1
+                size_totals[source] += len(sample.text)
+            return sample_counts, size_totals
+
+        default_counts, default_sizes = tally(default_samples)
+        size_counts, size_totals = tally(size_samples)
+
+        default_sample_ratio = default_counts["ds_short"] / default_counts.total()
+        size_sample_ratio = size_counts["ds_short"] / size_counts.total()
+        default_size_ratio = default_sizes["ds_short"] / default_sizes.total()
+        size_size_ratio = size_totals["ds_short"] / size_totals.total()
+        assert 0.45 <= default_sample_ratio <= 0.55, default_counts
+        assert default_size_ratio < 0.15, (default_sizes, default_size_ratio)
+        assert 0.45 <= size_size_ratio <= 0.55, size_totals
+        assert size_sample_ratio > 0.85, size_counts
+        assert size_sample_ratio > default_sample_ratio + 0.15, (
+            size_sample_ratio,
+            default_sample_ratio,
+        )
+
+    def test_blend_sample_size_save_restore(self):
+        torch.manual_seed(42)
+        worker_config = WorkerConfig(
+            rank=0,
+            world_size=1,
+            num_workers=0,
+            seed_offset=42,
+        )
+
+        short_size = 2
+        long_size = 50
+        self.create_fixed_size_text_dataset(
+            self.dataset_path / "ds_short", range(55), text_size=short_size
+        )
+        self.create_fixed_size_text_dataset(
+            self.dataset_path / "ds_long", range(100, 155), text_size=long_size
+        )
+
+        size_blend_mds_path = self.dataset_path / "metadataset_size_blend.yaml"
+        with open(size_blend_mds_path, "w") as f:
+            f.write(
+                "\n".join(
+                    [
+                        "__module__: megatron.energon",
+                        "__class__: MetadatasetV2",
+                        "splits:",
+                        "  train:",
+                        "    blend:",
+                        "      - weight: 1",
+                        "        path: ds_short",
+                        "        subflavors:",
+                        "          source: ds_short",
+                        "      - weight: 1",
+                        "        path: ds_long",
+                        "        subflavors:",
+                        "          source: ds_long",
+                    ]
+                )
+            )
+
+        def new_loader():
+            return get_savable_loader(
+                get_train_dataset(
+                    size_blend_mds_path,
+                    worker_config=worker_config,
+                    batch_size=None,
+                    shuffle_buffer_size=None,
+                    max_samples_per_sequence=None,
+                    task_encoder=SizeBlendTaskEncoder(),
+                ),
+                checkpoint_every_sec=0,
+                checkpoint_every_min_n_samples=1,
+            )
+
+        loader = new_loader()
+        list(zip(range(20), loader))
+        state = loader.save_state_rank()
+        order_1 = [sample.text for _, sample in zip(range(30), loader)]
+
+        loader = new_loader()
+        loader.restore_state_rank(state)
+        order_1_rest = [sample.text for _, sample in zip(range(len(order_1)), loader)]
+        assert order_1 == order_1_rest
+
+        blend_dataset = get_blend_dataset(loader.dataset.dataset)
+        assert isinstance(blend_dataset, BlendDataset)
+        assert blend_dataset.sample_size_fn is not None
+        assert sum(blend_dataset._emitted_sizes) > 0
 
     def test_s3(self):
         # Create a joined dataset configuration


### PR DESCRIPTION
The task encoder can now define a `blend_sample_size` function to determine the amount each sample contributes.

Balancing is deficit-based on historic distribution. We do not look-ahead for now, also we do not keep running averages of sizes (to simulate look-ahead).

There are two configs for this:
* `blend_sample_size_alpha`: this is the coefficient (i.e. strength of deficit). For =0, it would fall back to ignoring the size. For <1, softer correction, >1: more aggressive correction.
* `blend_sample_size_epsilon`: This is added to all deficits (so it depends on the unit/size of `blend_sample_size`). I.e. if 0, only consider undersampled sources in sampling. If >0, consider oversampled sources as well. Higher epsilon will down-weight deficits.