### PR TITLE
fix: call post_initialize() for dict path in load_dataset()

### DIFF
--- a/src/megatron/energon/metadataset/loader.py
+++ b/src/megatron/energon/metadataset/loader.py
@@ -25,6 +25,7 @@ def load_dataset(
             default_type=Metadataset,
             default_kwargs=dict(path=EPath("/dict"), **kwargs),
         )
+        mds.post_initialize()
         return mds
     path = EPath(path)
     ds_type = get_dataset_type(path)


### PR DESCRIPTION
Closes #241.

## Summary

`load_dataset()` accepts a `dict` as the `path` argument (for embedding metadataset definitions inline), but the dict code path does not call `post_initialize()` on the resulting `Metadataset`. This causes `AssertionError: assert self._dataset is not None` in `get_datasets()`.

The file-based code paths (`METADATASET`, `WEBDATASET`/`JSONL`) and `prepare_metadataset()` all call `post_initialize()` after `load_config()`. The dict branch is the only path that skips it.

## Changes

- Add `mds.post_initialize()` in the dict branch of `load_dataset()`, matching the existing file-based branches.

## Testing

Verified end-to-end with Megatron-Bridge `EnergonMultiModalDataModule` — passing a metadataset dict through `get_train_dataset()` now correctly initializes and returns data iterators without `AssertionError`.