### PR TITLE
fix: call post_initialize() for dict path in load_dataset()

### DIFF
--- a/src/megatron/energon/metadataset/loader.py
+++ b/src/megatron/energon/metadataset/loader.py
@@ -28,6 +28,7 @@ def load_dataset(
             default_type=Metadataset,
             default_kwargs=dict(path=EPath("/dict"), **kwargs),
         )
+        mds.post_initialize()
         return mds
     path = EPath(path)
     ds_type = get_dataset_type(path)


### PR DESCRIPTION
When a dict is passed to load_dataset(), post_initialize() was not called on the resulting Metadataset, causing AssertionError in get_datasets(). The file-based code paths already call it correctly.

Fixes https://github.com/NVIDIA/Megatron-Energon/issues/241


(cherry picked from commit 44a22370d143caccc3129202172f27b3f0758fa7)