### PR TITLE
Support configurable multiprocessing start method (`forkserver`/`spawn`) to avoid fork deadlocks

### DIFF
--- a/src/megatron/energon/cache/file_cache_pool.py
+++ b/src/megatron/energon/cache/file_cache_pool.py
@@ -454,6 +454,43 @@ class FileStoreCachePool(CachePool, ForkMixin):
             # Notify waiting threads that space is now available
             self._cache_space_available.notify_all()
 
+    def __getstate__(self):
+        """Return a picklable copy of the configuration.
+
+        Runtime fields (``ThreadPoolExecutor``, locks, pending tasks, per-process
+        ``cache_dir``) are not picklable / not safe to share across processes.
+        They are recreated in ``__setstate__``, mirroring ``__after_fork__``.
+        Required for ``forkserver``/``spawn`` dataloaders that serialize the
+        dataset (including ``cache_pool``) into worker processes.
+        """
+        assert len(self._pending_tasks) == 0, "Pending tasks should be empty before pickle"
+        # Do not mutate the live parent instance; only serialize configuration.
+        return {
+            "parent_cache_dir": self.parent_cache_dir,
+            "num_workers": self.num_workers,
+            "method": self.method,
+            "max_cache_size": self.max_cache_size,
+            "max_cache_count": self.max_cache_count,
+        }
+
+    def __setstate__(self, state):
+        self.parent_cache_dir = state["parent_cache_dir"]
+        self.num_workers = state["num_workers"]
+        self.method = state["method"]
+        self.max_cache_size = state["max_cache_size"]
+        self.max_cache_count = state["max_cache_count"]
+        self._pending_tasks = {}
+        self.current_cache_size = 0
+        self.current_cache_count = 0
+        self._shutting_down = False
+        self._worker_pool = None
+        self._lock = threading.RLock()
+        self._cache_space_available = threading.Condition(self._lock)
+        # Recreate process-local runtime state (pool + unique cache_dir).
+        self.__after_fork__(initial=True)
+        # Re-register fork hooks for this instance in the new process.
+        ForkMixin.__post_init__(self)
+
     def __before_fork__(self):
         # Ensure the worker pool is shutdown before the fork
         assert len(self._pending_tasks) == 0, "Pending tasks should be empty before fork"

--- a/src/megatron/energon/flavors/base_dataset.py
+++ b/src/megatron/energon/flavors/base_dataset.py
@@ -358,6 +358,11 @@ class SavableDataset(IterableDataset[T_sample], Savable, Generic[T_sample], ABC)
 
     @staticmethod
     def _function_config(fn: Callable) -> str:
+        import functools
+
+        if isinstance(fn, functools.partial):
+            # Render partials with their underlying function for debuggable configs.
+            return f"functools.partial({SavableDataset._function_config(fn.func)})"
         mod = inspect.getmodule(fn)
         if mod is not None:
             mod_name = mod.__name__

--- a/src/megatron/energon/flavors/crude.py
+++ b/src/megatron/energon/flavors/crude.py
@@ -7,6 +7,16 @@ from megatron.energon.epathlib import EPath
 from megatron.energon.flavors.webdataset import DefaultDecoderWebdatasetFactory
 
 
+def _always_true_part(part: str) -> bool:
+    """Picklable default for ``part_filter`` (forkserver/spawn support)."""
+    return True
+
+
+def _identity_sample(sample: Dict[str, Any]) -> Dict[str, Any]:
+    """Picklable default for ``sample_loader`` (forkserver/spawn support)."""
+    return sample
+
+
 class CrudeSample(dict):
     """Generic sample type to be processed later."""
 
@@ -25,7 +35,7 @@ class CrudeWebdataset(DefaultDecoderWebdatasetFactory[CrudeSample]):
         path: EPath,
         *,
         subflavors: Optional[Dict[str, Any]] = None,
-        part_filter: Union[str, List[str], Callable[[str], bool]] = lambda _: True,
+        part_filter: Union[str, List[str], Callable[[str], bool]] = _always_true_part,
         **kwargs,
     ):
         """
@@ -45,7 +55,7 @@ class CrudeWebdataset(DefaultDecoderWebdatasetFactory[CrudeSample]):
         super().__init__(
             path,
             subflavors=subflavors,
-            sample_loader=lambda sample: sample,
+            sample_loader=_identity_sample,
             part_filter=part_filter,
             **kwargs,
         )

--- a/src/megatron/energon/flavors/webdataset/default_generic_webdataset.py
+++ b/src/megatron/energon/flavors/webdataset/default_generic_webdataset.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import dataclasses
+import functools
 from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar, Union
 
 from megatron.energon.epathlib import EPath
@@ -13,6 +14,27 @@ from megatron.energon.flavors.webdataset.structs import FilteredSample
 from megatron.energon.module_loader import ModuleLoader
 
 T_sample = TypeVar("T_sample", covariant=True)
+
+
+def _part_in_set(part: str, parts) -> bool:
+    """Picklable replacement for ``lambda part: part in parts`` (forkserver/spawn support)."""
+    return part in parts
+
+
+def _apply_field_map(sample: Dict[str, Any], fields) -> Dict[str, Any]:
+    """Picklable replacement for the field_map sample loader lambda."""
+    return {k: field_access(sample, v) for k, v in fields.items()}
+
+
+def _wrap_sample(sample: Dict[str, Any], inner: Callable, subflavors) -> Dict[str, Any]:
+    """Picklable replacement for the sample wrapping lambda."""
+    return {
+        "__key__": sample["__key__"],
+        **inner(sample),
+        "__restore_key__": sample["__restore_key__"],
+        "__subflavors__": subflavors,
+        "__sources__": sample["__sources__"],
+    }
 
 
 class DefaultGenericWebdatasetFactory(BaseWebdatasetFactory[T_sample], Generic[T_sample]):
@@ -61,7 +83,7 @@ class DefaultGenericWebdatasetFactory(BaseWebdatasetFactory[T_sample], Generic[T
                 sample_loader = sample_loader
             if isinstance(part_filter, list):
                 parts = set(part_filter)
-                part_filter = lambda part: part in parts
+                part_filter = functools.partial(_part_in_set, parts=parts)
             elif isinstance(part_filter, str):
                 part_filter = module_loader.get_function(
                     part_filter, "part_filter", relative_path=path / MAIN_FOLDER_NAME
@@ -84,19 +106,15 @@ class DefaultGenericWebdatasetFactory(BaseWebdatasetFactory[T_sample], Generic[T
             ).issubset(field_map.keys()), (
                 f"field_map does not map to type {self.__sample_type__.__name__} fields"
             )
-            self._sample_loader = lambda sample: {
-                k: field_access(sample, v) for k, v in fields.items()
-            }
+            self._sample_loader = functools.partial(_apply_field_map, fields=fields)
             parts = set(access[0] for options in fields.values() for access in options)
-            part_filter = lambda part: part in parts
+            part_filter = functools.partial(_part_in_set, parts=parts)
         inner_sample_loader = self._sample_loader
-        self._sample_loader = lambda sample: {
-            "__key__": sample["__key__"],
-            **inner_sample_loader(sample),
-            "__restore_key__": sample["__restore_key__"],
-            "__subflavors__": self.subflavors,
-            "__sources__": sample["__sources__"],
-        }
+        self._sample_loader = functools.partial(
+            _wrap_sample,
+            inner=inner_sample_loader,
+            subflavors=subflavors or {},
+        )
         super().__init__(path, **kwargs, part_filter=part_filter)
         self.subflavors = subflavors or {}
 

--- a/src/megatron/energon/flavors/webdataset/default_generic_webdataset.py
+++ b/src/megatron/energon/flavors/webdataset/default_generic_webdataset.py
@@ -109,14 +109,16 @@ class DefaultGenericWebdatasetFactory(BaseWebdatasetFactory[T_sample], Generic[T
             self._sample_loader = functools.partial(_apply_field_map, fields=fields)
             parts = set(access[0] for options in fields.values() for access in options)
             part_filter = functools.partial(_part_in_set, parts=parts)
+        # Share one dict so later dataset.subflavors.update(...) is visible in samples.
+        resolved_subflavors = subflavors or {}
         inner_sample_loader = self._sample_loader
         self._sample_loader = functools.partial(
             _wrap_sample,
             inner=inner_sample_loader,
-            subflavors=subflavors or {},
+            subflavors=resolved_subflavors,
         )
         super().__init__(path, **kwargs, part_filter=part_filter)
-        self.subflavors = subflavors or {}
+        self.subflavors = resolved_subflavors
 
     def load_sample(self, sample: FilteredSample) -> T_sample:
         return self.__sample_type__(**self._sample_loader(sample))

--- a/src/megatron/energon/flavors/webdataset/joined_webdataset.py
+++ b/src/megatron/energon/flavors/webdataset/joined_webdataset.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import functools
 import os
 from abc import ABC
 from typing import (
@@ -16,6 +17,11 @@ from typing import (
     TypeVar,
     Union,
 )
+
+
+def _join_samples(*samples, joiner: Callable, inner_keys) -> Any:
+    """Picklable replacement for the ``lambda *samples: joiner(**dict(...))`` (forkserver/spawn)."""
+    return joiner(**dict(zip(inner_keys, samples)))
 
 from megatron.energon.cache import FileStore
 from megatron.energon.epathlib import EPath
@@ -112,7 +118,9 @@ class JoinedWebdatasetFactory(BaseCoreDatasetFactory[T_sample], Sharder, Generic
             inner_keys = list(inner_datasets.keys())
             self.inner_dataset_keys = inner_keys
             # Wrap the joiner to pass the samples as kwargs
-            self._sample_joiner = lambda *samples: joiner(**dict(zip(inner_keys, samples)))
+            self._sample_joiner = functools.partial(
+                _join_samples, joiner=joiner, inner_keys=tuple(inner_keys)
+            )
             inner_datasets = list(inner_datasets.values())
         else:
             assert isinstance(inner_datasets, Sequence)

--- a/src/megatron/energon/loader.py
+++ b/src/megatron/energon/loader.py
@@ -26,6 +26,7 @@ def get_savable_loader(
     watchdog_timeout_seconds: Optional[float] = 60,
     watchdog_initial_timeout_seconds: Optional[float] = None,
     fail_on_timeout: bool = False,
+    multiprocessing_context: str = "fork",
 ) -> SavableDataLoader[T]:
     """
 
@@ -72,6 +73,7 @@ def get_savable_loader(
         watchdog_timeout_seconds=watchdog_timeout_seconds,
         watchdog_initial_timeout_seconds=watchdog_initial_timeout_seconds,
         fail_on_timeout=fail_on_timeout,
+        multiprocessing_context=multiprocessing_context,
     )
 
 
@@ -84,6 +86,7 @@ def get_loader(
     watchdog_timeout_seconds: Optional[float] = 60,
     watchdog_initial_timeout_seconds: Optional[float] = None,
     fail_on_timeout: bool = False,
+    multiprocessing_context: str = "fork",
 ) -> BasicDataLoader[T]:
     """
     Get a dataloader for the given dataset.
@@ -116,4 +119,5 @@ def get_loader(
         watchdog_timeout_seconds=watchdog_timeout_seconds,
         watchdog_initial_timeout_seconds=watchdog_initial_timeout_seconds,
         fail_on_timeout=fail_on_timeout,
+        multiprocessing_context=multiprocessing_context,
     )

--- a/src/megatron/energon/savable_loader.py
+++ b/src/megatron/energon/savable_loader.py
@@ -689,6 +689,7 @@ class SavableDataLoader(DataLoader[T], Generic[T]):
         watchdog_timeout_seconds: Optional[float] = 60,
         watchdog_initial_timeout_seconds: Optional[float] = None,
         fail_on_timeout: bool = False,
+        multiprocessing_context: str = "fork",
     ):
         """
         Create the dataloader supporting saving and restoring the state.
@@ -719,6 +720,7 @@ class SavableDataLoader(DataLoader[T], Generic[T]):
             fail_on_timeout: If True, stops the whole process upon timeout, after printing a stack trace.
         """
         self.worker_config = dataset.worker_config
+        self._mp_ctx_name = multiprocessing_context
         self.id = self.next_id()
 
         dataset = WatchdogDataset(
@@ -737,9 +739,10 @@ class SavableDataLoader(DataLoader[T], Generic[T]):
                 freeze=gc_freeze_at_start,
             )
 
-        self.cmd_queues = [multiprocessing.Queue() for _ in range(self.worker_config.num_workers)]
+        ctx = torch.multiprocessing.get_context(self._mp_ctx_name)
+        self.cmd_queues = [ctx.Queue() for _ in range(self.worker_config.num_workers)]
         self.result_queues = [
-            multiprocessing.Queue() for _ in range(self.worker_config.num_workers)
+            ctx.Queue() for _ in range(self.worker_config.num_workers)
         ]
 
         num_procs = max(self.worker_config.num_workers, 1)
@@ -772,7 +775,7 @@ class SavableDataLoader(DataLoader[T], Generic[T]):
         if self.worker_config.num_workers > 0:
             kwargs["persistent_workers"] = True
             kwargs["prefetch_factor"] = prefetch_factor
-            kwargs["multiprocessing_context"] = "fork"
+            kwargs["multiprocessing_context"] = ctx
 
         # Assert that prefetch_factor works well with num_checkpoints.
         # This ensures that the oldest checkpoint is old enough to cover
@@ -1197,6 +1200,7 @@ class SavableDataLoader(DataLoader[T], Generic[T]):
             "persistent_workers": self.persistent_workers,
             "pin_memory": self.pin_memory,
             "prefetch_factor": None if self.num_workers == 0 else self.prefetch_factor,
+            "multiprocessing_context": self._mp_ctx_name,
             "dataset": self.dataset.config(),
         }
 
@@ -1222,6 +1226,7 @@ class BasicDataLoader(DataLoader[T], Generic[T]):
         watchdog_timeout_seconds: Optional[float] = 60,
         watchdog_initial_timeout_seconds: Optional[float] = None,
         fail_on_timeout: bool = False,
+        multiprocessing_context: str = "fork",
     ):
         """
         Create the dataloader supporting saving and restoring the state.
@@ -1243,6 +1248,7 @@ class BasicDataLoader(DataLoader[T], Generic[T]):
             fail_on_timeout: If True, stops the whole process upon timeout, after printing a stack trace.
         """
         self.worker_config = dataset.worker_config
+        self._mp_ctx_name = multiprocessing_context
 
         self.id = SavableDataLoader.next_id()
 
@@ -1268,12 +1274,13 @@ class BasicDataLoader(DataLoader[T], Generic[T]):
 
         self._worker_sample_counters = [0] * max(self.worker_config.num_workers, 1)
 
+        ctx = torch.multiprocessing.get_context(self._mp_ctx_name)
         kwargs = {}
         if self.worker_config.num_workers > 0:
             # These must not be specified for num_workers =0
             kwargs["persistent_workers"] = True
             kwargs["prefetch_factor"] = prefetch_factor
-            kwargs["multiprocessing_context"] = "fork"
+            kwargs["multiprocessing_context"] = ctx
 
         seed_per_worker = [
             self.worker_config.worker_seed(i) for i in range(self.worker_config.num_workers)
@@ -1369,6 +1376,7 @@ class BasicDataLoader(DataLoader[T], Generic[T]):
             "persistent_workers": self.persistent_workers,
             "pin_memory": self.pin_memory,
             "prefetch_factor": None if self.num_workers == 0 else self.prefetch_factor,
+            "multiprocessing_context": self._mp_ctx_name,
             "dataset": self.dataset.config(),
         }
 

--- a/src/megatron/energon/worker.py
+++ b/src/megatron/energon/worker.py
@@ -265,18 +265,26 @@ class WorkerConfig:
     def __getstate__(self):
         """Return a picklable copy of the state.
 
-        ``data_parallel_group`` holds a ``torch.distributed.ProcessGroup`` which is not
-        picklable. It is only needed in the main process (e.g. for ``global_rank()``), so it
-        is dropped here. This is required when the dataloader uses a multiprocessing start
-        method other than ``fork`` (e.g. ``forkserver``/``spawn``), where the dataset is
-        serialized to the worker processes instead of inherited via fork.
+        Non-picklable fields are dropped here. This is required when the dataloader uses a
+        multiprocessing start method other than ``fork`` (e.g. ``forkserver``/``spawn``),
+        where the dataset is serialized to the worker processes instead of inherited via fork.
+
+        - ``data_parallel_group``: a ``torch.distributed.ProcessGroup``, only needed in the
+          main process (e.g. for ``global_rank()``).
+        - ``_worker_debug_file``: an open file handle. It may already be opened in the main
+          process (e.g. ``SavableDataLoader.__init__`` logs at level >= 1). Workers reopen
+          their own file lazily in ``worker_log``.
         """
         state = {name: getattr(self, name) for name in type(self).__slots__}
         state.pop("data_parallel_group", None)
+        state.pop("_worker_debug_file", None)
+        state.pop("_worker_debug_file_worker_id", None)
         return state
 
     def __setstate__(self, state):
         state.setdefault("data_parallel_group", None)
+        state.setdefault("_worker_debug_file", None)
+        state.setdefault("_worker_debug_file_worker_id", None)
         for name, value in state.items():
             setattr(self, name, value)
 

--- a/src/megatron/energon/worker.py
+++ b/src/megatron/energon/worker.py
@@ -262,6 +262,24 @@ class WorkerConfig:
     def should_log(self, level: int) -> bool:
         return level <= self.worker_log_level
 
+    def __getstate__(self):
+        """Return a picklable copy of the state.
+
+        ``data_parallel_group`` holds a ``torch.distributed.ProcessGroup`` which is not
+        picklable. It is only needed in the main process (e.g. for ``global_rank()``), so it
+        is dropped here. This is required when the dataloader uses a multiprocessing start
+        method other than ``fork`` (e.g. ``forkserver``/``spawn``), where the dataset is
+        serialized to the worker processes instead of inherited via fork.
+        """
+        state = {name: getattr(self, name) for name in type(self).__slots__}
+        state.pop("data_parallel_group", None)
+        return state
+
+    def __setstate__(self, state):
+        state.setdefault("data_parallel_group", None)
+        for name, value in state.items():
+            setattr(self, name, value)
+
     def worker_log(self, data: dict) -> None:
         """Logs the given data to the worker debug file."""
         if self.worker_debug_path is None:

--- a/src/megatron/energon/wrappers/iter_map_dataset.py
+++ b/src/megatron/energon/wrappers/iter_map_dataset.py
@@ -25,6 +25,11 @@ T_sample = TypeVar("T_sample")
 T_sample_out = TypeVar("T_sample_out")
 
 
+def _identity_len(x: int) -> int:
+    """Picklable default for ``len_map_fn`` (forkserver/spawn support)."""
+    return x
+
+
 class IterMapDataset(BaseWrapperDataset[T_sample, T_sample_out], Generic[T_sample, T_sample_out]):
     """This dataset wrapper applies a custom function to transform the stream of samples and yield
     a new stream of samples.
@@ -46,7 +51,7 @@ class IterMapDataset(BaseWrapperDataset[T_sample, T_sample_out], Generic[T_sampl
         dataset: SavableDataset[T_sample],
         iter_map_fn: Callable[[Iterator[T_sample]], Iterator[T_sample_out]],
         *,
-        len_map_fn: Callable[[int], int] = lambda x: x,
+        len_map_fn: Callable[[int], int] = _identity_len,
         stateless_iter_fn: bool = False,
         iter_map_fn_config: Optional[Union[Dict[str, Any], Callable[[], Dict[str, Any]]]] = None,
         worker_config: WorkerConfig,

--- a/src/megatron/energon/wrappers/mix_batch_dataset.py
+++ b/src/megatron/energon/wrappers/mix_batch_dataset.py
@@ -16,6 +16,11 @@ T_batch_in = TypeVar("T_batch_in")
 T_batch = TypeVar("T_batch")
 
 
+def _identity_batch_mix(x: List[Any]) -> Any:
+    """Picklable default for ``batch_mix_fn`` (forkserver/spawn support)."""
+    return x
+
+
 def generic_concat(batch: List[Any]) -> Any:
     """Based on the types/shapes of the batch: Will either pad and stack, or return as list.
     Recurses structures (dict, dataclass, namedtuple) and applies the same logic to each field."""
@@ -85,7 +90,7 @@ class MixBatchDataset(BaseWrapperDataset[T_batch_in, T_batch], Generic[T_batch_i
         batch_size: int,
         batch_mix_fn: Callable[
             [List[T_batch_in]], Union[T_batch, Generator[T_batch, None, None]]
-        ] = lambda x: x,
+        ] = _identity_batch_mix,
         worker_config: WorkerConfig,
     ):
         """Construct a BlendDataset.

--- a/tests/test_file_cache_pool.py
+++ b/tests/test_file_cache_pool.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import gc
+import pickle
 import tempfile
 import threading
 import time
@@ -683,6 +684,34 @@ class TestFileStoreCachePool(unittest.TestCase):
             del result2
             gc.collect()
             assert not cache_path.is_file()
+        finally:
+            pool.close()
+
+    def test_pickle_roundtrip(self):
+        """forkserver/spawn serialize the cache pool; runtime state must be rebuilt."""
+        pool = FileStoreCachePool(parent_cache_dir=self.temp_path, num_workers=2, method="pickle")
+        try:
+            parent_cache_dir = pool.cache_dir
+            restored = pickle.loads(pickle.dumps(pool))
+            try:
+                self.assertEqual(restored.parent_cache_dir, pool.parent_cache_dir)
+                self.assertEqual(restored.num_workers, 2)
+                self.assertEqual(restored.method, "pickle")
+                self.assertEqual(restored.max_cache_size, pool.max_cache_size)
+                self.assertEqual(restored.max_cache_count, pool.max_cache_count)
+                self.assertIsNotNone(restored._worker_pool)
+                self.assertTrue(restored.cache_dir.exists())
+                # Each process/instance gets its own cache subdirectory.
+                self.assertNotEqual(restored.cache_dir, parent_cache_dir)
+                # Parent instance must remain intact after pickling.
+                self.assertIsNotNone(pool._worker_pool)
+                self.assertTrue(parent_cache_dir.exists())
+
+                mock_store = MockFileStore({"file1": b"test data 1"})
+                lazy = restored.get_lazy(mock_store, "file1")
+                self.assertEqual(lazy.get(), b"test data 1")
+            finally:
+                restored.close()
         finally:
             pool.close()
 

--- a/tests/test_forkserver.py
+++ b/tests/test_forkserver.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests that the Energon dataloader works with the ``forkserver`` multiprocessing
+start method (instead of the default ``fork``). This exercises the full pickle path
+of the dataset + worker_config to the worker processes and verifies that saving and
+restoring progress still works.
+"""
+
+import gc
+import tempfile
+import unittest
+import warnings
+from pathlib import Path
+
+import torch
+import webdataset as wds
+
+from megatron.energon import (
+    DefaultTaskEncoder,
+    TextSample,
+    WorkerConfig,
+    get_savable_loader,
+    get_train_dataset,
+)
+from megatron.energon.flavors.webdataset.config import MAIN_FOLDER_NAME
+
+# Speed up tests significantly by reducing the torch status check interval for broken worker shutdown
+try:
+    torch.utils.data._utils.worker.MP_STATUS_CHECK_INTERVAL = 0.1
+except AttributeError:
+    pass
+
+
+class TestForkserver(unittest.TestCase):
+    def setUp(self):
+        warnings.simplefilter("ignore", ResourceWarning)
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.dataset_path = Path(self.temp_dir.name)
+        self.dataset_path.mkdir(exist_ok=True, parents=True)
+        self.create_text_test_dataset(self.dataset_path)
+
+    def tearDown(self):
+        gc.collect()
+        self.temp_dir.cleanup()
+
+    @staticmethod
+    def create_text_test_dataset(path: Path):
+        (path / "parts").mkdir(exist_ok=True, parents=True)
+        with wds.ShardWriter(f"{path}/parts/data-%d.tar", maxcount=100) as shard_writer:
+            for idx in range(55):
+                shard_writer.write(
+                    {
+                        "__key__": f"{idx:06d}",
+                        "txt": f"{idx}".encode(),
+                    }
+                )
+                if idx in (1, 3, 6, 10, 20, 30, 40, 50):
+                    shard_writer.next_stream()
+        total_shards = len(list((path / "parts").glob("data-*.tar")))
+
+        from megatron.energon.flavors import BaseWebdatasetFactory
+
+        BaseWebdatasetFactory.prepare_dataset(
+            path,
+            [f"parts/data-{{0..{total_shards - 1}}}.tar"],
+            split_parts_ratio=[("train", 1.0)],
+            shuffle_seed=None,
+        )
+        with open(path / MAIN_FOLDER_NAME / "dataset.yaml", "w") as f:
+            f.write(
+                "\n".join(
+                    [
+                        "sample_type:",
+                        "  __module__: megatron.energon",
+                        "  __class__: TextSample",
+                        "field_map:",
+                        "  text: txt",
+                    ]
+                )
+            )
+
+    def _make_loader(self, num_workers, mp_ctx, seed_offset=0):
+        worker_config = WorkerConfig(
+            rank=0, world_size=1, num_workers=num_workers, seed_offset=seed_offset
+        )
+        ds = get_train_dataset(
+            self.dataset_path,
+            split_part="train",
+            sample_type=TextSample,
+            worker_config=worker_config,
+            batch_size=1,
+            shuffle_buffer_size=42,
+            max_samples_per_sequence=2,
+            task_encoder=DefaultTaskEncoder(),
+        )
+        return get_savable_loader(ds, multiprocessing_context=mp_ctx)
+
+    def test_forkserver_save_restore(self):
+        num_workers = 2
+
+        # First loader: consume a few samples, save state, then consume more.
+        loader1a = self._make_loader(num_workers, "forkserver")
+        data_pre = [data.text[0] for idx, data in zip(range(7), loader1a)]
+        state = loader1a.save_state_rank()
+        data_post = [data.text[0] for idx, data in zip(range(20), loader1a)]
+        assert len(data_pre) == 7
+        assert len(data_post) == 20
+
+        # Second loader: restore from the saved state and verify it continues identically.
+        loader1b = self._make_loader(num_workers, "forkserver")
+        loader1b.restore_state_rank(state)
+        data_restored = [data.text[0] for idx, data in zip(range(20), loader1b)]
+
+        self.assertEqual(data_post, data_restored)
+
+    def test_forkserver_matches_fork_order(self):
+        # For the same seed, forkserver should yield the same sequence as fork
+        # (the start method must not affect the data ordering).
+        num_workers = 2
+
+        fork_loader = self._make_loader(num_workers, "fork", seed_offset=42)
+        fork_order = [data.text[0] for idx, data in zip(range(55 * 5), fork_loader)]
+
+        forkserver_loader = self._make_loader(num_workers, "forkserver", seed_offset=42)
+        forkserver_order = [
+            data.text[0] for idx, data in zip(range(55 * 5), forkserver_loader)
+        ]
+
+        self.assertEqual(fork_order, forkserver_order)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_forkserver.py
+++ b/tests/test_forkserver.py
@@ -23,6 +23,7 @@ from megatron.energon import (
     get_savable_loader,
     get_train_dataset,
 )
+from megatron.energon.cache import FileStoreCachePool
 from megatron.energon.flavors.webdataset.config import MAIN_FOLDER_NAME
 
 # Speed up tests significantly by reducing the torch status check interval for broken worker shutdown
@@ -128,6 +129,39 @@ class TestForkserver(unittest.TestCase):
         ]
 
         self.assertEqual(fork_order, forkserver_order)
+
+    def test_forkserver_with_file_cache_pool(self):
+        # FileStoreCachePool embeds a ThreadPoolExecutor / locks that are not picklable.
+        # forkserver must serialize the pool into workers via __getstate__/__setstate__.
+        num_workers = 2
+        worker_config = WorkerConfig(rank=0, world_size=1, num_workers=num_workers)
+        ds = get_train_dataset(
+            self.dataset_path,
+            split_part="train",
+            sample_type=TextSample,
+            worker_config=worker_config,
+            batch_size=1,
+            shuffle_buffer_size=42,
+            max_samples_per_sequence=2,
+            task_encoder=DefaultTaskEncoder(),
+        )
+        cache_pool = FileStoreCachePool(
+            parent_cache_dir=self.dataset_path / "cache",
+            num_workers=1,
+        )
+        try:
+            loader = get_savable_loader(
+                ds,
+                multiprocessing_context="forkserver",
+                cache_pool=cache_pool,
+            )
+            data = [sample.text[0] for _, sample in zip(range(20), loader)]
+            self.assertEqual(len(data), 20)
+            # Parent pool must remain usable after workers were spawned from a pickled copy.
+            self.assertIsNotNone(cache_pool._worker_pool)
+            self.assertTrue(cache_pool.cache_dir.exists())
+        finally:
+            cache_pool.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_metadataset.py
+++ b/tests/test_metadataset.py
@@ -763,6 +763,7 @@ class TestDataset(unittest.TestCase):
             "persistent_workers": False,
             "pin_memory": True,
             "prefetch_factor": None,
+            "multiprocessing_context": "fork",
             "dataset": {
                 "type": "MapDataset",
                 "dataset": {
@@ -858,7 +859,7 @@ class TestDataset(unittest.TestCase):
                                                     "mds": "mds",
                                                     "__subflavor__": "ds1",
                                                 },
-                                                "sample_loader": "megatron.energon.flavors.webdataset.default_generic_webdataset.DefaultGenericWebdatasetFactory.__init__.<locals>.<lambda>",
+                                                "sample_loader": "functools.partial(megatron.energon.flavors.webdataset.default_generic_webdataset._wrap_sample)",
                                                 "image_decode": "torchrgb",
                                                 "av_decode": "AVDecoder",
                                                 "video_decode_audio": False,
@@ -952,7 +953,7 @@ class TestDataset(unittest.TestCase):
                                                     "mds": "mds",
                                                     "__subflavor__": "ds2",
                                                 },
-                                                "sample_loader": "megatron.energon.flavors.webdataset.default_generic_webdataset.DefaultGenericWebdatasetFactory.__init__.<locals>.<lambda>",
+                                                "sample_loader": "functools.partial(megatron.energon.flavors.webdataset.default_generic_webdataset._wrap_sample)",
                                                 "image_decode": "torchrgb",
                                                 "av_decode": "AVDecoder",
                                                 "video_decode_audio": False,


### PR DESCRIPTION
## Problem

The dataloader can **deadlock with the default `fork` start method** in environments where the
parent process already has other threads holding locks (OpenMP, MKL, CUDA, HuggingFace tokenizers,
logging handlers, etc.). `fork()` only copies the calling thread, so locks held elsewhere stay
permanently locked in the worker → deadlock.

## Solution

Make the multiprocessing start method configurable (`fork` / `forkserver` / `spawn`). `forkserver`/
`spawn` start a fresh interpreter and avoid inherited locks. Default stays `fork` — no behavior change.

## Changes

**Configurable start method**
- `loader.py`: `get_loader` / `get_savable_loader` accept `multiprocessing_context: str = "fork"`.
- `savable_loader.py`: loaders create queues + torch `DataLoader` context from
  `torch.multiprocessing.get_context(mp_ctx)`; `config()` now includes `multiprocessing_context`.
- `worker.py`: `WorkerConfig` gains `__getstate__`/`__setstate__` that drops the non-picklable
  `data_parallel_group` (ProcessGroup) on serialization.

**Make dataset callables picklable** (required because `forkserver`/`spawn` serialize the dataset to workers)
- `default_generic_webdataset.py`: lambdas → `functools.partial` of `_part_in_set`, `_apply_field_map`, `_wrap_sample`.
- `joined_webdataset.py`: joiner lambda → `functools.partial(_join_samples, ...)`.
- `crude.py`: default lambdas → module-level `_always_true_part` / `_identity_sample`.
- `mix_batch_dataset.py`: default `batch_mix_fn` → `_identity_batch_mix`.
- `iter_map_dataset.py`: default `len_map_fn` → `_identity_len`.

**Supporting**
- `base_dataset.py`: `_function_config` renders `functools.partial` as readable `functools.partial(<module>.<qualname>)`.
- `tests/test_forkserver.py` (new): save/restore + fork-order equivalence under `forkserver`.
- `tests/test_metadataset.py`: updated reference `config()` for the new `multiprocessing_context` key and `sample_loader` repr.

## Usage

```python
loader = get_savable_loader(dataset, multiprocessing_context="forkserver")  # or "spawn"
