### PR TITLE
Fix rare RNG bug in `WorkerRng.choice_idx`

### DIFF
--- a/src/megatron/energon/rng.py
+++ b/src/megatron/energon/rng.py
@@ -63,7 +63,9 @@ class WorkerRng(Savable):
             # 10 even on CPU.
             cdf = torch.cumsum(probs, dim=0)
             val = torch.rand(1, generator=self.rng) * cdf[-1]
-            return torch.searchsorted(cdf, val).item()
+            # Upper bound, such that entries with zero probability are never selected (a lower
+            # bound would return index 0 if val is exactly 0 and probs[0] is 0).
+            return torch.searchsorted(cdf, val, right=True).item()
 
     def choice(self, l: List[T], probs: Optional[torch.Tensor] = None) -> T:
         if probs is None:


### PR DESCRIPTION
`choice_idx` samples via inverse CDF, but looked `val = rand() * cdf[-1]` up with `torch.searchsorted`'s default lower bound (`right=False`), which returns the first index with `cdf[i] >= val`. Since `torch.rand` returns exactly `0.0` with probability 2^-24 (~1 in 16.8M draws), a draw of `0.0` selected index `0` even when `probs[0] == 0`. 

Switching to the upper bound (`right=True`) returns the first index with `cdf[i] > val`, which never selects zero-probability entries and maps `val == 0.0` to the first entry with positive mass. Behavior only differs on exact ties and the number of random draws is unchanged, so the RNG stream and existing sampling behavior stay identical.