### PR TITLE
fix(checkpoint): support single-file (DP=1) checkpoints as redist input

### DIFF
--- a/src/megatron/energon/tools/checkpoint.py
+++ b/src/megatron/energon/tools/checkpoint.py
@@ -74,7 +74,8 @@ def detect_and_replicate_pattern(file_list):
             values = [int(x) if x.isdigit() else None for x in all_tokens_at_pos]
             # If *any* of them is None or they vary, we track that as "differences".
             # But let's see if indeed they differ across the files or not.
-            if len(set(values)) > 1:
+            # A single file has no variation, but its numeric tokens are still candidates.
+            if len(set(values)) > 1 or len(tokenized) == 1:
                 # This token position changes among files
                 num_positions.append(pos)
             else:
@@ -87,9 +88,14 @@ def detect_and_replicate_pattern(file_list):
 
     # We expect exactly 1 changing numeric token position
     if len(num_positions) == 0:
-        raise Exception("No numeric portion found that differs among files.")
+        raise Exception(
+            "No numeric portion usable as the rank index found in the checkpoint file name(s)."
+        )
     if len(num_positions) > 1:
-        raise Exception("Multiple numeric portions found that differ. Not a single pattern.")
+        raise Exception(
+            "Multiple numeric portions found in the checkpoint file name(s); "
+            "cannot determine which one is the rank index."
+        )
 
     varying_pos = num_positions[0]
 
@@ -307,10 +313,9 @@ def command_redist(
     required=True,
 )
 def command_info(input_files: List[EPath]):
-    """Display information about a checkpoint.
+    """Display information about one or more checkpoint files.
 
-    Read a checkpoint from CHECKPOINT_PATH (either a single file or directory with *.pt files)
-    and display information about it.
+    Read checkpoint files from INPUT_FILES and display information about them.
     """
 
     # Load the checkpoint(s)


### PR DESCRIPTION
## Problem

`energon checkpoint redist` rejects any single-file checkpoint: [`detect_and_replicate_pattern`](https://github.com/tkmtakada/Megatron-Energon/blob/feature/redist_tool/src/megatron/energon/tools/checkpoint.py#L24) requires a numeric token whose value *differs across files*, which cannot be detected from one file, and the CLI aborts with:

```
Exception: No numeric portion found that differs among files.
```

## Changes

- `detect_and_replicate_pattern`: for single-file input, numeric token positions are taken as candidates instead of requiring variation across files (a single file has no variation to detect, so any numeric token is a candidate for the rank index)
- Clarified the error messages of the two rejection cases ("no usable numeric portion" / "multiple numeric portions, cannot determine the rank index"); they now describe the actual problem for both single- and multi-file inputs
- Fixed the docstring of `checkpoint info`, which incorrectly claimed to accept a directory (it accepts checkpoint files)

## Testing

- Existing `test_redist` passes unchanged (multi-file pattern detection is not modified); `ruff check` passes
- Verified end-to-end with the real CLI: DP=1 (single-file) checkpoint creation → `checkpoint redist` → `checkpoint info`

<details>
<summary>Verification steps</summary>

```python
# 0) Create a DP=1 checkpoint
import torch
from megatron.energon import WorkerConfig, get_train_dataset
from megatron.energon.loader import get_savable_loader

loader = get_savable_loader(
    get_train_dataset(
        dataset_path,
        split_part="train",
        worker_config=WorkerConfig(rank=0, world_size=1, num_workers=4),
        batch_size=2,
        shuffle_buffer_size=42,
        max_samples_per_sequence=2,
    )
)
for _ in zip(range(20), loader):  # advance the loader state
    pass
state = loader.save_state_rank()  # only one rank with DP=1
torch.save(state, "state_rank0.pt")
```

```bash
# 1) Check the saved DP=1 state file (only one rank file)
ls /path/to/ckpt/
#   state_rank0.pt

# 2) Create the output directory beforehand
#    (Note: checkpoint redist requires it to exist; pre-existing limitation, see below)
mkdir -p /path/to/out

# 3) Redistribute DP=1 -> DP=2 (4 workers in total become 2 ranks x 2 workers)
energon checkpoint redist /path/to/ckpt/state_rank0.pt /path/to/out --new-world-size 2

# 4) Check the redistribution result
energon checkpoint info /path/to/out/state_rank0.pt /path/to/out/state_rank1.pt
```
</details>
