### PR TITLE
Coalesce duplicate leaf datasets in weighted blends

### DIFF
--- a/docs/source/basic/metadataset.md
+++ b/docs/source/basic/metadataset.md
@@ -83,6 +83,22 @@ When referring to datasets under `val:` obviously `split_part: val` is the defau
 
 Energon also supports blending by specifying the number of repetitions for each dataset using [Epochized Blending](../advanced/epochized_blending).
 
+## Duplicate Weighted References
+
+If the same leaf dataset is reached more than once in a weighted blend, including
+through nested metadatasets, Energon combines identical references into one sample
+stream and sums their weights. A warning identifies the duplicate dataset.
+This avoids drawing the same shuffle sequence from two independent loaders.
+
+References remain separate when their effective split, subset, subflavors,
+shuffle settings, dataset configuration, split configuration, or auxiliary data
+differ. Joined datasets and `blend_epochized` repetitions are unchanged.
+Traversal-only inspection still reports the original references.
+
+Coalescing changes the loader structure for blends that contained duplicates.
+Do not reuse loader states saved from the previous duplicate structure; restart
+the data iteration when adopting the corrected blend.
+
 (sect-subflavors)=
 ## Subflavors
 

--- a/src/megatron/energon/metadataset/dataset_loader.py
+++ b/src/megatron/energon/metadataset/dataset_loader.py
@@ -92,20 +92,35 @@ class DatasetLoader(DatasetLoaderInterface):
         subset: Optional[DatasetSubset] = None,
         **kwargs,
     ) -> LoadedDatasetList:
+        dataset = self.get_dataset(
+            training=training,
+            split_part=split_part,
+            worker_config=worker_config,
+            subflavors=subflavors,
+            shuffle_over_epochs=shuffle_over_epochs_multiplier,
+            subset=subset,
+            **kwargs,
+        )
+        # Keep the loading inputs: factory.config() does not retain split names
+        # or alternate dataset configuration files.
+        source_config = dict(
+            path=str(EPath(self.path)),
+            factory=type(dataset),
+            split_part=self.split_part if self.split_part is not None else split_part,
+            dataset_config=kwargs.get("dataset_config") or self.dataset_config or "dataset.yaml",
+            split_config=kwargs.get("split_config") or self.split_config or "split.yaml",
+            subflavors=dataset.subflavors,
+            shuffle_over_epochs=shuffle_over_epochs_multiplier,
+            subset=subset.config() if subset is not None else None,
+            kwargs={k: v for k, v in kwargs.items() if k not in ("dataset_config", "split_config")},
+        )
         return LoadedDatasetList(
             blend_mode=DatasetBlendMode.NONE,
             datasets=[
                 LoadedDataset(
-                    dataset=self.get_dataset(
-                        training=training,
-                        split_part=split_part,
-                        worker_config=worker_config,
-                        subflavors=subflavors,
-                        shuffle_over_epochs=shuffle_over_epochs_multiplier,
-                        subset=subset,
-                        **kwargs,
-                    ),
+                    dataset=dataset,
                     weight=None,
+                    _source_config=source_config if type(self) is DatasetLoader else None,
                 )
             ],
         )

--- a/src/megatron/energon/metadataset/loader_interface.py
+++ b/src/megatron/energon/metadataset/loader_interface.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Sequence, Union
 
@@ -31,6 +31,7 @@ class LoadedDataset:
     weight: Union[float, int, None] = None
     repetitions: Union[float, int, None] = None
     aux: Optional[Dict[str, FileStore]] = None
+    _source_config: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
 
 
 @edataclass

--- a/src/megatron/energon/metadataset/merge.py
+++ b/src/megatron/energon/metadataset/merge.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import warnings
+from dataclasses import replace
+from typing import Any
+
+from megatron.energon.cache.file_store import SystemFileStore, WebdatasetFileStore
+from megatron.energon.metadataset.loader_interface import LoadedDataset
+
+
+def _same_config(left: Any, right: Any) -> bool:
+    if left is right:
+        return True
+    if type(left) is not type(right):
+        return False
+    if type(left) is dict:
+        return left.keys() == right.keys() and all(
+            _same_config(value, right[key]) for key, value in left.items()
+        )
+    if type(left) in (list, tuple):
+        return len(left) == len(right) and all(_same_config(a, b) for a, b in zip(left, right))
+    if type(left) in (str, int, float, bool, bytes, type(None)):
+        return left == right
+    # Custom values (such as decoders or tensors) must be the same object.
+    return False
+
+
+def _aux_config(dataset: LoadedDataset) -> dict:
+    return {
+        name: (type(store), store.get_path())
+        if type(store) in (SystemFileStore, WebdatasetFileStore)
+        else store
+        for name, store in (dataset.aux or {}).items()
+    }
+
+
+def merge_weighted_datasets(datasets: list[LoadedDataset]) -> list[LoadedDataset]:
+    """Combine identical leaf loading inputs without creating duplicate sample streams."""
+    merged: list[LoadedDataset] = []
+    by_path: dict[str, list[LoadedDataset]] = {}
+    for dataset in datasets:
+        source = dataset._source_config
+        if source is None:
+            merged.append(dataset)
+            continue
+        candidates = by_path.setdefault(source["path"], [])
+        for previous in candidates:
+            if _same_config(source, previous._source_config) and _same_config(
+                _aux_config(dataset), _aux_config(previous)
+            ):
+                previous.weight += dataset.weight
+                warnings.warn(
+                    f"Combining duplicate weighted dataset {source['path']} into one sample stream.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                break
+        else:
+            entry = replace(dataset)
+            candidates.append(entry)
+            merged.append(entry)
+    return merged

--- a/src/megatron/energon/metadataset/metadataset.py
+++ b/src/megatron/energon/metadataset/metadataset.py
@@ -16,6 +16,7 @@ from megatron.energon.metadataset.loader_interface import (
     LoadedDatasetList,
     TraversedDatasetReference,
 )
+from megatron.energon.metadataset.merge import merge_weighted_datasets
 from megatron.energon.worker import WorkerConfig
 
 
@@ -241,7 +242,7 @@ class MetadatasetBlender:
                 datasets.append(loaded_dataset)
         return LoadedDatasetList(
             blend_mode=DatasetBlendMode.DATASET_WEIGHT,
-            datasets=datasets,
+            datasets=merge_weighted_datasets(datasets),
         )
 
 

--- a/src/megatron/energon/metadataset/metadataset_v2.py
+++ b/src/megatron/energon/metadataset/metadataset_v2.py
@@ -35,6 +35,7 @@ from megatron.energon.metadataset.loader_interface import (
     LoadedDatasetList,
     TraversedDatasetReference,
 )
+from megatron.energon.metadataset.merge import merge_weighted_datasets
 from megatron.energon.metadataset.metadataset import Metadataset
 from megatron.energon.worker import WorkerConfig
 
@@ -640,7 +641,7 @@ class MetadatasetBlend(DatasetLoaderInterface, SubsetRatioMixin):
                 datasets.append(loaded_dataset)
         return LoadedDatasetList(
             blend_mode=DatasetBlendMode.DATASET_WEIGHT,
-            datasets=datasets,
+            datasets=merge_weighted_datasets(datasets),
         )
 
 

--- a/tests/test_metadataset_duplicates.py
+++ b/tests/test_metadataset_duplicates.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import gc
+import tempfile
+import unittest
+import warnings
+from copy import deepcopy
+from pathlib import Path
+
+import yaml
+
+from megatron.energon import (
+    WorkerConfig,
+    get_loader,
+    get_savable_loader,
+    get_train_dataset,
+    load_dataset,
+)
+from megatron.energon.flavors.webdataset.config import MAIN_FOLDER_NAME
+from megatron.energon.task_encoder.base import DefaultTaskEncoder
+from tests import test_metadataset_v2 as fixtures
+
+
+class TestDuplicateBlendDatasets(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.worker = WorkerConfig(rank=0, world_size=1, num_workers=0)
+        for name, start in (("ds1", 0), ("ds2", 100)):
+            fixtures.TestDataset.create_text_test_dataset(
+                self.root / name, range(start, start + 100), range(100)
+            )
+
+    def write_blend(self, name, entries, version=2, mode="blend"):
+        path = self.root / name
+        path.write_text(
+            yaml.safe_dump(
+                {
+                    "__module__": "megatron.energon",
+                    "__class__": "MetadatasetV2" if version == 2 else "Metadataset",
+                    "splits": {
+                        "train": {
+                            mode if version == 2 else "datasets": [
+                                deepcopy(entry) for entry in entries
+                            ]
+                        }
+                    },
+                }
+            )
+        )
+        return path
+
+    def load(self, path):
+        return load_dataset(path).get_datasets(
+            training=True, split_part="train", worker_config=self.worker
+        )
+
+    def test_nested_duplicates_preserve_combined_weights(self):
+        for version in (1, 2):
+            with self.subTest(version=version):
+                self.write_blend(
+                    "inner.yaml",
+                    [
+                        {"path": "./ds1", "weight": 1},
+                        {"path": "./ds2", "weight": 3},
+                    ],
+                    version,
+                )
+                path = self.write_blend(
+                    "outer.yaml",
+                    [
+                        {"path": "./ds1", "weight": 2},
+                        {"path": "./inner.yaml", "weight": 4},
+                    ],
+                    version,
+                )
+                with warnings.catch_warnings(record=True) as caught:
+                    result = self.load(path)
+                self.assertEqual(len(result.datasets), 2)
+                self.assertAlmostEqual(result.datasets[0].weight, 0.5)
+                self.assertAlmostEqual(result.datasets[1].weight, 0.5)
+                self.assertTrue(any("duplicate" in str(w.message) for w in caught))
+
+    def test_nested_duplicate_has_one_sample_stream(self):
+        self.write_blend("inner.yaml", [{"path": "./ds1"}])
+        path = self.write_blend(
+            "outer.yaml",
+            [
+                {"path": "./ds1"},
+                {"path": "./inner.yaml"},
+            ],
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            dataset = get_train_dataset(
+                path,
+                worker_config=self.worker,
+                batch_size=1,
+                shuffle_buffer_size=None,
+                max_samples_per_sequence=None,
+                task_encoder=DefaultTaskEncoder(),
+            )
+        loader = get_loader(dataset)
+        iterator = iter(loader)
+        values = [next(iterator).text[0] for _ in range(100)]
+        self.assertEqual(len(set(values)), 100)
+        self.assertTrue(any("duplicate" in str(w.message) for w in caught))
+        del iterator, loader, dataset
+        gc.collect()
+
+    def test_distinct_leaf_settings_remain_separate(self):
+        meta = self.root / "ds1" / MAIN_FOLDER_NAME
+        (meta / "other-dataset.yaml").write_text((meta / "dataset.yaml").read_text())
+        (meta / "other-split.yaml").write_text((meta / "split.yaml").read_text())
+        split = yaml.safe_load((meta / "split.yaml").read_text())
+        split["split_parts"]["val"] = list(split["split_parts"]["train"])
+        (meta / "split.yaml").write_text(yaml.safe_dump(split))
+        cases = [
+            {"split_part": "val"},
+            {"subset": {"range": [0, 50]}},
+            {"subflavors": {"purpose": ["distinct", "training"]}},
+            {"shuffle_over_epochs_multiplier": 2},
+            {"dataset_config": "other-dataset.yaml"},
+            {"split_config": "other-split.yaml"},
+            {"aux": {"data": {"fs_path": "."}}},
+        ]
+        for overrides in cases:
+            with self.subTest(overrides=overrides):
+                path = self.write_blend(
+                    "distinct.yaml",
+                    [
+                        {"path": "./ds1"},
+                        {"path": "./ds1", **overrides},
+                    ],
+                )
+                with warnings.catch_warnings(record=True) as caught:
+                    result = self.load(path)
+                self.assertEqual(len(result.datasets), 2)
+                self.assertFalse(any("duplicate" in str(w.message) for w in caught))
+
+    def test_matching_auxiliary_data_merges(self):
+        entry = {"path": "./ds1", "aux": {"data": {"fs_path": "."}}}
+        path = self.write_blend("aux.yaml", [entry, entry])
+        with self.assertWarnsRegex(UserWarning, "duplicate"):
+            result = self.load(path)
+        self.assertEqual(len(result.datasets), 1)
+        self.assertEqual(result.datasets[0].weight, 1.0)
+        self.assertEqual(result.datasets[0].aux["data"].get_path(), str(self.root))
+
+    def test_epochized_repetitions_remain_separate(self):
+        path = self.write_blend(
+            "epochized.yaml",
+            [
+                {"path": "./ds1", "repetitions": 1},
+                {"path": "./ds1", "repetitions": 2},
+            ],
+            mode="blend_epochized",
+        )
+        result = self.load(path)
+        self.assertEqual(len(result.datasets), 2)
+        self.assertEqual([d.repetitions for d in result.datasets], [1, 2])
+
+    def test_merged_blend_save_restore_preserves_sequence(self):
+        path = self.write_blend(
+            "resume.yaml",
+            [
+                {"path": "./ds1"},
+                {"path": "./ds2"},
+                {"path": "./ds1"},
+            ],
+        )
+
+        def make_loader():
+            with self.assertWarnsRegex(UserWarning, "duplicate"):
+                dataset = get_train_dataset(
+                    path,
+                    worker_config=self.worker,
+                    batch_size=1,
+                    shuffle_buffer_size=None,
+                    max_samples_per_sequence=None,
+                    task_encoder=DefaultTaskEncoder(),
+                )
+            return get_savable_loader(dataset)
+
+        loader = make_loader()
+        list(zip(range(20), loader))
+        state = loader.save_state_rank()
+        expected = [batch.text for _, batch in zip(range(40), loader)]
+        restored = make_loader()
+        restored.restore_state_rank(state)
+        actual = [batch.text for _, batch in zip(range(40), restored)]
+        self.assertEqual(actual, expected)
+        del loader, restored
+        gc.collect()


### PR DESCRIPTION
## Summary

Closes #266.

Coalesce identical leaf datasets after flattening weighted blends in both metadataset formats, preserving first-occurrence order and summing their sampling weights. A warning identifies each duplicate instead of silently creating independent loaders with the same shuffle sequence.

The comparison retains resolved loading inputs because factory configurations omit split names and alternate configuration filenames. Different splits, subsets, subflavors, shuffle settings, configuration files, and auxiliary stores remain separate. Joined datasets, epochized repetitions, and traversal-only inspection are unchanged.

## Validation

- The original nested-blend reproduction returned only 51 unique samples in 100 draws. The regression now returns all 100 once.
- Four regression assertions failed on the original code, covering duplicate flattening in both formats, sample duplication, and matching auxiliary data.
- `python -m unittest tests.test_metadataset tests.test_metadataset_v2 tests.test_metadataset_duplicates -v`: 33 passed, including save/restore sequence equivalence.
- `ruff check` with the repository-locked Ruff 0.15.17: passed.
- `ruff format --check src/megatron/energon/metadataset tests/test_metadataset_duplicates.py`: passed.
- Sphinx HTML documentation build and wheel build: passed.
- `git diff --check`: passed.

Validation ran on Linux arm64, Python 3.12, and PyTorch 2.10.0. The repository-wide test suite was not run.

## Compatibility

Blends that previously contained duplicates have a different loader structure after coalescing. The documentation explains that old loader states from that structure must not be reused. Newly created combined blends preserve save/restore behavior.
