### PR TITLE
Keep watchdog diagnostics running when local values cannot be printed

### DIFF
--- a/src/megatron/energon/watchdog.py
+++ b/src/megatron/energon/watchdog.py
@@ -289,13 +289,17 @@ class Watchdog:
 
 def repr_short(obj: Any) -> str:
     """
-    Return a short repr of an object.
+    Return a short repr of an object, or a diagnostic if it cannot be represented.
     """
-    if isinstance(obj, torch.Tensor):
-        if isinstance(obj, ShardedTensorBase) or obj.is_cuda:
-            return "<CUDA tensor>"
+    try:
+        if isinstance(obj, torch.Tensor):
+            if isinstance(obj, ShardedTensorBase) or obj.is_cuda:
+                return "<CUDA tensor>"
 
-    s = repr(obj)
+        s = repr(obj)
+    except Exception as exc:
+        # A failing local must not prevent the remaining stacks or timeout callback.
+        s = f"<unrepresentable {type(obj).__name__}: {type(exc).__name__}>"
     if len(s) > PRINT_LOCAL_MAX_LENGTH:
         s = s[: PRINT_LOCAL_MAX_LENGTH // 2] + "..." + s[-PRINT_LOCAL_MAX_LENGTH // 2 :]
     return s

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import contextlib
+import io
+import unittest
+from unittest.mock import Mock, patch
+
+import torch
+
+from megatron.energon.watchdog import PRINT_LOCAL_MAX_LENGTH, Watchdog, repr_short
+
+
+class Unprintable:
+    def __repr__(self):
+        raise RuntimeError("Cannot format this value")
+
+
+class UninspectableTensor(torch.Tensor):
+    @property
+    def is_cuda(self):
+        raise RuntimeError("Cannot inspect this tensor")
+
+
+class TestWatchdog(unittest.TestCase):
+    def test_unprintable_locals(self):
+        for value in (Unprintable(), [Unprintable()], {"sample": Unprintable()}):
+            with self.subTest(value_type=type(value).__name__):
+                self.assertEqual(
+                    repr_short(value),
+                    f"<unrepresentable {type(value).__name__}: RuntimeError>",
+                )
+
+    def test_tensor_inspection_failure(self):
+        value = torch.empty(0).as_subclass(UninspectableTensor)
+        self.assertEqual(repr_short(value), "<unrepresentable UninspectableTensor: RuntimeError>")
+
+    def test_existing_representations(self):
+        for value in (None, 42, {"sample": "text"}, torch.tensor([1, 2])):
+            self.assertEqual(repr_short(value), repr(value))
+        value = "x" * PRINT_LOCAL_MAX_LENGTH
+        representation = repr(value)
+        self.assertEqual(
+            repr_short(value),
+            representation[: PRINT_LOCAL_MAX_LENGTH // 2]
+            + "..."
+            + representation[-PRINT_LOCAL_MAX_LENGTH // 2 :],
+        )
+
+    def test_timeout_continues_after_unprintable_local(self):
+        def stalled_worker():
+            broken = Unprintable()
+            following = "still visible"
+            yield broken, following
+
+        worker = stalled_worker()
+        next(worker)
+        callback = Mock()
+        watchdog = Watchdog(timeout=60, callback=callback, enabled=False)
+        output = io.StringIO()
+        try:
+            with (
+                patch("sys._current_frames", return_value={-1: worker.gi_frame}),
+                contextlib.redirect_stdout(output),
+            ):
+                watchdog._on_timeout()
+        finally:
+            watchdog.finish()
+            worker.close()
+        callback.assert_called_once_with()
+        self.assertIn("<unrepresentable Unprintable: RuntimeError>", output.getvalue())
+        self.assertIn("following: 'still visible'", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A watchdog stack dump can stop before printing the remaining frames or invoking its timeout callback when a local object's `repr()` raises. Tensor attribute inspection can fail in the same way, and containers holding unprintable objects reach the same unguarded path.

Catch exceptions from tensor inspection and representation and emit a bounded diagnostic containing the object type and exception type. Existing successful representations and the CUDA/sharded-tensor guard retain their behavior.

Validation:
- The new tests produced five errors on the original implementation, including three object shapes. All four test methods pass with the fix.
- All 142 tests passed across all 15 test modules on Linux arm64, Python 3.11.15, and CPU-only PyTorch 2.10.0. Modules ran in separate processes to stay within local memory limits.
- Ruff check, targeted Ruff format check, license-header checks, Sphinx HTML build, wheel build, and `git diff --check` passed.

The GPU-specific failure was not reproduced on CUDA hardware. Regression tests use real PyTorch CPU tensors with failing attribute inspection, direct and nested objects whose representation raises, and a stack-dump test that verifies the timeout callback still runs.

Closes #251.

Prepared with AI assistance; reproduction and validation ran locally. The commit includes the required DCO sign-off.
